### PR TITLE
Remove "field_farm_" prefixes from field names.

### DIFF
--- a/src/client/components/EditLog.vue
+++ b/src/client/components/EditLog.vue
@@ -77,7 +77,7 @@
       <div class="form-item form-item-name form-group">
         <ul class="list-group">
           <li
-            v-for="(asset, i) in logs[currentLogIndex].field_farm_asset"
+            v-for="(asset, i) in logs[currentLogIndex].asset"
             v-bind:key="`log-${i}-${Math.floor(Math.random() * 1000000)}`"
             class="list-group-item">
             {{ asset.name }}
@@ -163,7 +163,7 @@
       <div class="form-item form-item-name form-group">
         <ul class="list-group">
           <li
-            v-for="(area, i) in logs[currentLogIndex].field_farm_area"
+            v-for="(area, i) in logs[currentLogIndex].area"
             v-bind:key="`log-${i}-${Math.floor(Math.random() * 1000000)}`"
             class="list-group-item">
             {{ area.name }}
@@ -176,7 +176,7 @@
 
 
       <!-- We're using a button to attach the current location to the log
-      as a field_farm_geofield -->
+      as a geofield -->
 
       <div v-if="useGeolocation" class="form-item form-item-name form-group">
         <button
@@ -194,9 +194,9 @@
         <ul class="list-group">
           <li
             class="list-group-item"
-            v-if="logs[currentLogIndex].field_farm_geofield.length > 0">
-            {{ logs[currentLogIndex].field_farm_geofield[0].geom }}
-            <span class="remove-list-item" @click="updateCurrentLog('field_farm_geofield', [])">
+            v-if="logs[currentLogIndex].geofield.length > 0">
+            {{ logs[currentLogIndex].geofield[0].geom }}
+            <span class="remove-list-item" @click="updateCurrentLog('geofield', [])">
               &#x2715;
             </span>
           </li>
@@ -344,30 +344,30 @@ export default {
 
     addAsset(id) {
       const selectedAsset = this.assets.find(asset => asset.id === id);
-      const newAssets = this.logs[this.currentLogIndex].field_farm_asset.concat(selectedAsset);
-      this.updateCurrentLog('field_farm_asset', newAssets);
+      const newAssets = this.logs[this.currentLogIndex].asset.concat(selectedAsset);
+      this.updateCurrentLog('asset', newAssets);
     },
 
     addArea(tid) {
       if (tid !== '') {
         const selectedArea = this.areas.find(area => area.tid === tid);
-        const newAreas = this.logs[this.currentLogIndex].field_farm_area.concat(selectedArea);
-        this.updateCurrentLog('field_farm_area', newAreas);
+        const newAreas = this.logs[this.currentLogIndex].area.concat(selectedArea);
+        this.updateCurrentLog('area', newAreas);
         this.checkAreas();
       }
       this.checkAreas();
     },
 
     removeAsset(asset) {
-      const newAssets = this.logs[this.currentLogIndex].field_farm_asset
+      const newAssets = this.logs[this.currentLogIndex].asset
         .filter(_asset => _asset.id !== asset.id);
-      this.updateCurrentLog('field_farm_asset', newAssets);
+      this.updateCurrentLog('asset', newAssets);
     },
 
     removeArea(area) {
-      const newAreas = this.logs[this.currentLogIndex].field_farm_area
+      const newAreas = this.logs[this.currentLogIndex].area
         .filter(_area => _area.tid !== area.tid);
-      this.updateCurrentLog('field_farm_area', newAreas);
+      this.updateCurrentLog('area', newAreas);
     },
 
     getPhoto() {
@@ -393,7 +393,7 @@ export default {
         this.attachGeo = true;
         const location = JSON.parse(`[{"geom":"POINT (${this.geolocation.Longitude} ${this.geolocation.Latitude})"}]`);
         console.log(`ATTACH GEOLOCATION: ${location}`);
-        this.updateCurrentLog('field_farm_geofield', location);
+        this.updateCurrentLog('geofield', location);
       }
     },
 
@@ -401,7 +401,7 @@ export default {
       console.log('CALLED CHECKAREAS; DOING CHECKINSIDE');
       // Use checkInside with each area to see if the current location is inside an area
       this.filteredAreas.forEach((area) => {
-        if (area.field_farm_geofield[0] !== undefined && this.geolocation.Longitude !== undefined) {
+        if (area.geofield[0] !== undefined && this.geolocation.Longitude !== undefined) {
           // If the current location is inside an area, add the area to the log
           const lonlat = [this.geolocation.Longitude, this.geolocation.Latitude];
           // checkInNear requires a point, an area, and a radius around the point in kilometers
@@ -420,13 +420,13 @@ export default {
       added to the current log.
     */
     filteredAssets() {
-      const selectedAssets = this.logs[this.currentLogIndex].field_farm_asset;
+      const selectedAssets = this.logs[this.currentLogIndex].asset;
       return this.assets.filter(asset =>
         !selectedAssets.some(selAsset => asset.id === selAsset.id),
       );
     },
     filteredAreas() {
-      const selectedAreas = this.logs[this.currentLogIndex].field_farm_area;
+      const selectedAreas = this.logs[this.currentLogIndex].area;
       return this.areas.filter(area =>
         !selectedAreas.some(selArea => area.tid === selArea.tid),
       );
@@ -441,11 +441,11 @@ export default {
       this.updateCurrentLog('images', this.photoLoc);
     },
     geolocation() {
-      // When geolocation is set, EITHER set field_farm_geofield OR select areas based on location
+      // When geolocation is set, EITHER set geofield OR select areas based on location
       if (this.attachGeo && this.geolocation.Longitude !== undefined) {
         const location = JSON.parse(`[{"geom":"POINT (${this.geolocation.Longitude} ${this.geolocation.Latitude})"}]`);
         console.log(`ATTACH GEOLOCATION: ${location}`);
-        this.updateCurrentLog('field_farm_geofield', location);
+        this.updateCurrentLog('geofield', location);
         this.isWorking = false;
         // If we are getting local areas
       }

--- a/src/client/store/geoModule.js
+++ b/src/client/store/geoModule.js
@@ -52,7 +52,7 @@ export default {
         return geoJSON;
       }
 
-      const geometry = params.area.field_farm_geofield[0].geom;
+      const geometry = params.area.geofield[0].geom;
       const geomJSON = geoJSONify(geometry);
 
       // Now I'll check whether the point is inside the polygon (isInside)

--- a/src/client/store/logFactory.js
+++ b/src/client/store/logFactory.js
@@ -15,9 +15,9 @@ export default function ({
   wasPushedToServer = false,
   isReadyToSync = false,
   remoteUri = '',
-  field_farm_asset = [], // eslint-disable-line camelcase
-  field_farm_area = [], // eslint-disable-line camelcase
-  field_farm_geofield = [], // eslint-disable-line camelcase
+  asset = [], // eslint-disable-line camelcase
+  area = [], // eslint-disable-line camelcase
+  geofield = [], // eslint-disable-line camelcase
 } = {}) {
   return {
     log_owner,
@@ -34,8 +34,8 @@ export default function ({
     wasPushedToServer,
     isReadyToSync,
     remoteUri,
-    field_farm_asset,
-    field_farm_area,
-    field_farm_geofield,
+    asset,
+    area,
+    geofield,
   };
 }

--- a/src/data/farmSync.js
+++ b/src/data/farmSync.js
@@ -95,7 +95,7 @@ export default function (host, user, password) {
 
           // If an option object is passed, set defaults and parse the string params
           const { page = null, type = '' } = opts;
-          const typeParams = (type !== '') ? `field_farm_area_type=${type}` : '';
+          const typeParams = (type !== '') ? `area_type=${type}` : '';
           const pageParams = (page !== null) ? `page=${page}` : '';
 
           // If no page # is passed, get all of them

--- a/src/data/httpModule.js
+++ b/src/data/httpModule.js
@@ -14,7 +14,7 @@ export default {
       return farm().area.get().then((res) => {
         // If a successful response is received, delete and replace all areas
         commit('deleteAllAreas');
-        const areas = res.map(({ tid, name, field_farm_geofield }) => ({ tid, name, field_farm_geofield })); // eslint-disable-line camelcase, max-len
+        const areas = res.map(({ tid, name, geofield }) => ({ tid, name, geofield })); // eslint-disable-line camelcase, max-len
         commit('addAreas', areas);
         console.log('Finished updating areas!');
       }).catch((err) => { throw err; });

--- a/src/data/logFactory.js
+++ b/src/data/logFactory.js
@@ -38,9 +38,9 @@ export default function (
     isCachedLocally = false,
     wasPushedToServer = false,
     remoteUri = '',
-    field_farm_asset = [], // eslint-disable-line camelcase
-    field_farm_area = [], // eslint-disable-line camelcase
-    field_farm_geofield = [], // eslint-disable-line camelcase
+    asset = [], // eslint-disable-line camelcase
+    area = [], // eslint-disable-line camelcase
+    geofield = [], // eslint-disable-line camelcase
   } = {},
   dest,
 ) {
@@ -66,18 +66,18 @@ export default function (
       isCachedLocally: JSON.parse(isCachedLocally),
       wasPushedToServer: JSON.parse(wasPushedToServer),
       remoteUri,
-      field_farm_asset: parseObjects(field_farm_asset), // eslint-disable-line no-use-before-define
-      field_farm_area: parseObjects(field_farm_area), // eslint-disable-line no-use-before-define
-      field_farm_geofield: parseObjects(field_farm_geofield), // eslint-disable-line no-use-before-define, max-len
+      asset: parseObjects(asset), // eslint-disable-line no-use-before-define
+      area: parseObjects(area), // eslint-disable-line no-use-before-define
+      geofield: parseObjects(geofield), // eslint-disable-line no-use-before-define, max-len
     };
   }
   // The format for sending logs to the farmOS REST Server.
   if (dest === SERVER) {
     // Just take the id from the assets/areas before sending
-    const assets = field_farm_asset.map(asset => ({ id: asset.id }));
-    const areas = field_farm_area.map(area => ({ id: area.tid }));
+    const assets = asset.map(asset => ({ id: asset.id }));
+    const areas = area.map(area => ({ id: area.tid }));
     log = {
-      field_farm_notes: {
+      notes: {
         format: 'farm_format',
         value: `<p>${notes}</p>\n`,
       },
@@ -86,10 +86,10 @@ export default function (
       done,
       type,
       timestamp,
-      field_farm_images: images,
-      field_farm_asset: assets,
-      field_farm_area: areas,
-      field_farm_geofield,
+      images: images,
+      asset: assets,
+      area: areas,
+      geofield,
     };
     /*
       Only return id property if one has already been assigned by the server,
@@ -113,9 +113,9 @@ export default function (
       done,
       wasPushedToServer,
       remoteUri,
-      field_farm_asset: JSON.stringify(field_farm_asset),
-      field_farm_area: JSON.stringify(field_farm_area),
-      field_farm_geofield: JSON.stringify(field_farm_geofield),
+      asset: JSON.stringify(asset),
+      area: JSON.stringify(area),
+      geofield: JSON.stringify(geofield),
     };
     /*
       Only return local_id property if one has already been assigned by WebSQL,


### PR DESCRIPTION
**This is just for informational purposes.**

I know @jgaehring and @alexadamsmith are working on some big changes, and so this will need to be redone anyway, but I thought it would be helpful to make a pull request anyway, even if we immediately close it (or wait to update it after the big changes are done).

In farmOS, I'm removing the "field_farm_" prefixes from field names, so this commit performs a simple search and replace to remove those prefixes from here.

Note: the old field names will still work in farmOS... the names without prefix are actually just aliases. So that means that the old client code will work with the new farmOS code, but once you make this change it will no longer work with *old* farmOS code. So if you have a local development site set up, you'll need to update that.

Here is what the the JSON for a log looks like without the "field_farm_" prefixes:

![screenshot from 2019-03-06 16-47-00](https://user-images.githubusercontent.com/95381/53919929-77478480-4039-11e9-8edc-e9fc4cfea13f.png)

Beautiful, isn't it? :-)