### PR TITLE
adds images to logs with existing images

### DIFF
--- a/src/utils/makeLog.js
+++ b/src/utils/makeLog.js
@@ -244,7 +244,6 @@ export default {
   fromSql: makeLogFactory(SQL, STORE),
   fromServer: makeLogFactory(SERVER, STORE),
 };
-
 /*
   parseImages and parseObjects are used both in src: store and src: SQL
   For now, I will retain them in their original form, and use only on the data: property
@@ -258,9 +257,32 @@ export default {
 */
 function parseImages(x) {
   if (typeof x === 'object') {
-    return x;
+    // Image references obtained from the server are objects
+    const imageArray = [];
+    if (Array.isArray(x)) {
+      x.forEach((img) => {
+        if (typeof img === 'string') {
+          // imageArray.push(checkJSON(img));
+          imageArray.push(img);
+        } else {
+          Object.keys(img).forEach((key) => {
+            if (img[key].id) {
+              imageArray.push(`${img[key].id}`);
+            } else {
+              imageArray.push(img[key]);
+            }
+          });
+        }
+      });
+    } else {
+      Object.keys(x).forEach((key) => {
+        imageArray.push(x[key]);
+      });
+    }
+    return imageArray;
   }
   if (typeof x === 'string') {
+    // return (x === '') ? [] : [].concat(checkJSON(x));
     return (x === '') ? [] : [].concat(x);
   }
   throw new Error(`${x} cannot be parsed as an image array`);

--- a/src/vue-plugins/http/index.js
+++ b/src/vue-plugins/http/index.js
@@ -100,12 +100,6 @@ export default {
         if (action.type === 'sendLogs') {
           store.dispatch('updateUnits');
         }
-
-/*
-        if (action.type === 'loadCachedUnits') {
-          store.dispatch('updateUnits');
-        }
-        */
       },
     });
   },

--- a/src/vue-plugins/http/module.js
+++ b/src/vue-plugins/http/module.js
@@ -85,12 +85,30 @@ export default {
         });
       }
 
+      // format images for the payload
+      function processImages(image) {
+        if (Array.isArray(image)) {
+          const imgArray = [];
+          image.forEach((img) => {
+            // Files begin with 'data:'.  Retain file strings, turn ref strings into objects
+            if (img.charAt(0) === 'd') {
+              imgArray.push(img);
+            } else {
+              imgArray.push({ fid: img });
+            }
+          });
+          return imgArray;
+        }
+        return image;
+      }
+
       // Send records to the server, unless the user isn't logged in
       if (localStorage.getItem('token')) {
         payload.indices.map((index) => { // eslint-disable-line consistent-return, array-callback-return, max-len
           // Either send or post logs, depending on whether they originated on the server
           // Logs originating on the server possess an ID field; others do not.
           const newLog = makeLog.toServer(rootState.farm.logs[index]);
+          newLog.images = processImages(newLog.images);
           // I need to check wasPushedToServer, which is not in logFactory Server
           const synced = rootState.farm.logs[index].wasPushedToServer;
           if (!synced) {


### PR DESCRIPTION
This seems to work smoothly on the dev server and on Android!

When a log already has images, the app receives the image reference or references from the server, stores them in a log.images array, and adds image files to the array when selected.

When changes to an existing log are PUT to the server, images: is an array consisting of stringified image files, and image references formatted as {fid: "idnumber"}.