### PR TITLE
Add categories

### DIFF
--- a/src/client/components/EditLog.vue
+++ b/src/client/components/EditLog.vue
@@ -60,6 +60,19 @@
                 {{ (cat) ? cat.name : '' }}
               </option>
           </select>
+          <ul v-if="logs[currentLogIndex].log_category.data.length > 0" class="list-group">
+            <li
+              v-for="(cat, i) in logs[currentLogIndex].log_category.data"
+              v-bind:key="`log-${i}-${Math.floor(Math.random() * 1000000)}`"
+              class="list-group-item">
+              {{ (categoryNames.length > 0) ? categoryNames[i] : '' }}
+              <!--
+              <span class="remove-list-item" @click="removeQuant(i)">
+                &#x2715;
+              </span>
+              -->
+            </li>
+          </ul>
         </div>
       </div>
 
@@ -593,6 +606,20 @@ export default {
           });
         });
         return unitNames;
+      }
+      return [];
+    },
+    categoryNames() {
+      if (this.categories.length > 0 && this.logs[this.currentLogIndex].log_category.data.length > 0) {
+        let catNames = []
+        this.logs[this.currentLogIndex].log_category.data.forEach((logCat) => {
+          this.categories.forEach((cat) => {
+            if (parseInt(cat.tid, 10) === parseInt(logCat.id, 10)) {
+              catNames.push(cat.name);
+            }
+          });
+        });
+        return catNames;
       }
       return [];
     },

--- a/src/client/components/EditLog.vue
+++ b/src/client/components/EditLog.vue
@@ -50,6 +50,20 @@
       </div>
 
       <div class="form-item form-item-name form-group">
+        <label for="type" class="control-label ">Log Categories</label>
+        <div class="input-group">
+          <select
+            class="custom-select col-sm-3 ">
+              <option
+                v-for="cat in categories"
+                :value="cat.tid">
+                {{ (cat) ? cat.name : '' }}
+              </option>
+          </select>
+        </div>
+      </div>
+
+      <div class="form-item form-item-name form-group">
         <label for="notes" class="control-label ">Notes</label>
         <textarea
           :value="logs[currentLogIndex].notes.data"
@@ -369,6 +383,7 @@ export default {
     'localArea',
     'useGeolocation',
     'units',
+    'categories',
     // Set by router via edit/:type props=true
     'type',
   ],

--- a/src/client/components/EditLog.vue
+++ b/src/client/components/EditLog.vue
@@ -53,6 +53,7 @@
         <label for="type" class="control-label ">Log Categories</label>
         <div class="input-group">
           <select
+            @input="addCategory($event.target.value)"
             class="custom-select col-sm-3 ">
               <option
                 v-for="cat in categories"
@@ -66,11 +67,9 @@
               v-bind:key="`log-${i}-${Math.floor(Math.random() * 1000000)}`"
               class="list-group-item">
               {{ (categoryNames.length > 0) ? categoryNames[i] : '' }}
-              <!--
-              <span class="remove-list-item" @click="removeQuant(i)">
+              <span class="remove-list-item" @click="removeCategory(i)">
                 &#x2715;
               </span>
-              -->
             </li>
           </ul>
         </div>
@@ -466,6 +465,12 @@ export default {
       this.$store.commit('updateCurrentLog', newProps);
     },
 
+    addCategory(id) {
+      const catReference = { id: id, resource: 'taxonomy_term'};
+      const newCategories = this.logs[this.currentLogIndex].log_category.data.concat(catReference);
+      this.updateCurrentLog('log_category', newCategories);
+    },
+
     addAsset(id) {
       const assetReference = { id: id, resource: 'farm_asset'};
       const newAssets = this.logs[this.currentLogIndex].asset.data.concat(assetReference);
@@ -507,7 +512,13 @@ export default {
     removeQuant(index) {
       const newQuant = this.logs[this.currentLogIndex].quantity.data;
       newQuant.splice(index, 1);
-      this.updateCurrentLog('quantity', JSON.stringify(newQuant));
+      this.updateCurrentLog('quantity', newQuant);
+    },
+
+    removeCategory(index) {
+      const newCat = this.logs[this.currentLogIndex].log_category.data;
+      newCat.splice(index, 1);
+      this.updateCurrentLog('category', newCat);
     },
 
     getPhoto() {

--- a/src/client/components/Logs.vue
+++ b/src/client/components/Logs.vue
@@ -19,6 +19,7 @@
       :localArea='localArea'
       :useGeolocation='useGeolocation'
       :units='units'
+      :categories='categories'
       :userId='userId'
     />
 
@@ -95,6 +96,7 @@ export default {
     localArea: state => state.farm.localArea,
     units: state => state.farm.units,
     userId: state => state.shell.user.uid,
+    categories: state => state.farm.categories,
   }),
   created() {
     this.$store.dispatch('onLogsComponentCreated');

--- a/src/client/store/index.js
+++ b/src/client/store/index.js
@@ -66,6 +66,7 @@ const farmModule = {
     geolocation: {},
     localArea: [],
     units: [],
+    categories: [],
   },
   mutations: {
     changeFarmName(state, name) {
@@ -87,14 +88,21 @@ const farmModule = {
     addUnits(state, units) {
       state.units = state.units.concat(units);
     },
+    addCategories(state, cats) {
+      state.categories = state.categories.concat(cats);
+      console.log('CATEGORIES IN THE STORE: ', state.categories);
+    },
     /*
-    updateUnitsFromCache is distinct from addUnits because it is NOT a hook for updating
-    units in the database.  It ONLY adds units to the local store.
-    updateUnitsFromCache is called by websql/module/loadCachedUnits
+    updateUnitsFromCache and updateCategoriesFromCache are distinct from addUnits because
+    they are NOT hooks for updating units/ cats in the database.  They ONLY add units/ cats
+    to the local store.  updateUnitsFromCache is called by websql/module/loadCachedUnits
     addUnits is called by http/module/updateUnits
     */
     updateUnitsFromCache(state, units) {
       state.units = state.units.concat(units);
+    },
+    updateCategoriesFromCache(state, cats) {
+      state.categories = state.categories.concat(cats);
     },
     /*
       This pushes the new log onto the `logs` array, and b/c `.push()` returns
@@ -158,6 +166,9 @@ const farmModule = {
     deleteAllUnits(state) {
       state.units = [];
     },
+    deleteAllCategories(state) {
+      state.categories = [];
+    },
     clearLogs(state) {
       state.logs.splice(0, state.logs.length);
     },
@@ -169,6 +180,9 @@ const farmModule = {
     },
     clearUnits(state) {
       state.units.splice(0, state.units.length);
+    },
+    clearCategories(state) {
+      state.categories.splice(0, state.categories.length);
     },
     setPhotoLoc(state, loc) {
       state.photoLoc = loc;

--- a/src/client/store/index.js
+++ b/src/client/store/index.js
@@ -90,7 +90,6 @@ const farmModule = {
     },
     addCategories(state, cats) {
       state.categories = state.categories.concat(cats);
-      console.log('CATEGORIES IN THE STORE: ', state.categories);
     },
     /*
     updateUnitsFromCache and updateCategoriesFromCache are distinct from addUnits because

--- a/src/utils/makeLog.js
+++ b/src/utils/makeLog.js
@@ -27,6 +27,7 @@ const makeLogFactory = (src, dest) => {
       log_owner = { changed: null, data: '' }, // eslint-disable-line camelcase
       // Quantity will be an array of objects, similar to area or asset
       quantity = { changed: null, data: [] },
+      log_category = { changed: null, data: [] }, // eslint-disable-line camelcase
       id,
       local_id, // eslint-disable-line camelcase
       name = { changed: null, data: '' },
@@ -52,6 +53,7 @@ const makeLogFactory = (src, dest) => {
           log_owner,
           notes,
           quantity: { data: parseObjects(quantity.data), changed: quantity.changed }, // eslint-disable-line no-use-before-define, max-len
+          log_category: { data: parseObjects(log_category.data), changed: log_category.changed }, // eslint-disable-line no-use-before-define, max-len
           id,
           local_id,
           name,
@@ -87,6 +89,7 @@ const makeLogFactory = (src, dest) => {
           images: images.data,
           asset: asset.data,
           quantity: quantity.data,
+          log_category: log_category.data,
         };
         /*
           Only return id property if one has already been assigned by the server,
@@ -109,6 +112,7 @@ const makeLogFactory = (src, dest) => {
           log_owner: JSON.stringify(log_owner),
           notes: JSON.stringify(notes),
           quantity: JSON.stringify(quantity),
+          log_category: JSON.stringify(log_category),
           id,
           name: JSON.stringify(name),
           type: JSON.stringify(type),
@@ -143,6 +147,7 @@ const makeLogFactory = (src, dest) => {
       log_owner = { changed: null, data: '' }, // eslint-disable-line camelcase
       // quantity will be an array of objects, similar to area or asset
       quantity = { changed: null, data: [] },
+      log_category = { changed: null, data: [] }, // eslint-disable-line camelcase
       id,
       local_id, // eslint-disable-line camelcase
       name = { changed: null, data: '' },
@@ -162,6 +167,7 @@ const makeLogFactory = (src, dest) => {
         log_owner: JSON.parse(log_owner),
         notes: JSON.parse(notes),
         quantity: { data: parseObjects(JSON.parse(quantity).data), changed: JSON.parse(quantity).changed }, // eslint-disable-line no-use-before-define, max-len
+        log_category: { data: parseObjects(JSON.parse(log_category).data), changed: JSON.parse(log_category).changed }, // eslint-disable-line no-use-before-define, max-len
         id: id === 'undefined' ? undefined : id,
         local_id,
         name: JSON.parse(name),
@@ -192,6 +198,7 @@ const makeLogFactory = (src, dest) => {
       const {
         log_owner, // eslint-disable-line camelcase
         quantity,
+        log_category, // eslint-disable-line camelcase
         id,
         local_id, // eslint-disable-line camelcase
         name,
@@ -209,6 +216,7 @@ const makeLogFactory = (src, dest) => {
         log_owner: { data: log_owner, changed: nowStamp },
         notes: { data: parseNotes(notes), changed: nowStamp }, // eslint-disable-line no-use-before-define, max-len
         quantity: { data: quantity, changed: nowStamp },
+        log_category: { data: log_category, changed: nowStamp },
         local_id,
         name: { data: name, changed: nowStamp },
         type: { data: type, changed: nowStamp },

--- a/src/vue-plugins/http/index.js
+++ b/src/vue-plugins/http/index.js
@@ -95,10 +95,10 @@ export default {
         if (action.type === 'loadCachedAreas') {
           store.dispatch('updateAreas');
         }
-        // Only update units when logs have been obtained from the server
-
+        // Only update units and categories when logs have been obtained from the server
         if (action.type === 'sendLogs') {
-          store.dispatch('updateUnits');
+          store.dispatch('updateUnits')
+            .then(store.dispatch('updateCategories'));
         }
       },
     });

--- a/src/vue-plugins/http/module.js
+++ b/src/vue-plugins/http/module.js
@@ -37,7 +37,6 @@ export default {
     updateCategories({ commit }) {
       // Return categories only.
       return farm().term.get('farm_log_categories').then((res) => {
-        console.log('CATEGORIES FROM SERVER: ', res);
         commit('deleteAllCategories');
         const cats = res.list.map(({ tid, name }) => ({ tid, name }));
         commit('addCategories', cats);
@@ -137,7 +136,6 @@ export default {
       const syncDate = localStorage.getItem('syncDate');
       return farm().log.get(rootState.shell.settings.logFilters, localStorage.getItem('token'))
         .then((res) => {
-          console.log('LOGS FROM SERVER', res)
           // See whether logs are new, or currently in the store
           // If res is a single log, check vs current, run through the logFactory and call addLog
           // If res is multiple, check each vs current, run through logFactory and call addLogs

--- a/src/vue-plugins/http/module.js
+++ b/src/vue-plugins/http/module.js
@@ -34,6 +34,12 @@ export default {
         commit('addUnits', units);
       }).catch((err) => { throw err; });
     },
+    updateCategories({ commit }) {
+      // Return categories only.
+      return farm().term.get('farm_log_categories').then((res) => {
+        console.log('CATEGORIES FROM SERVER: ', res);
+      }).catch((err) => { throw err; });
+    },
     // SEND LOGS TO SERVER (step 2 of sync)
     sendLogs({ commit, rootState }, payload) {
       // Update logs in the database and local store after send completes
@@ -128,6 +134,7 @@ export default {
       const syncDate = localStorage.getItem('syncDate');
       return farm().log.get(rootState.shell.settings.logFilters, localStorage.getItem('token'))
         .then((res) => {
+          console.log('LOGS FROM SERVER', res)
           // See whether logs are new, or currently in the store
           // If res is a single log, check vs current, run through the logFactory and call addLog
           // If res is multiple, check each vs current, run through logFactory and call addLogs

--- a/src/vue-plugins/http/module.js
+++ b/src/vue-plugins/http/module.js
@@ -38,6 +38,9 @@ export default {
       // Return categories only.
       return farm().term.get('farm_log_categories').then((res) => {
         console.log('CATEGORIES FROM SERVER: ', res);
+        commit('deleteAllCategories');
+        const cats = res.list.map(({ tid, name }) => ({ tid, name }));
+        commit('addCategories', cats);
       }).catch((err) => { throw err; });
     },
     // SEND LOGS TO SERVER (step 2 of sync)

--- a/src/vue-plugins/websql/index.js
+++ b/src/vue-plugins/websql/index.js
@@ -11,10 +11,11 @@ export default {
         store.commit('clearAssets');
         store.commit('clearAreas');
         store.commit('clearUnits');
-        store.dispatch('loadCachedLogs');
+        store.commit('clearCategories');
         store.dispatch('loadCachedAssets');
         store.dispatch('loadCachedAreas');
         store.dispatch('loadCachedUnits');
+        store.dispatch('loadCachedCategories');
       }
     });
     store.subscribe((mutation) => {
@@ -52,6 +53,9 @@ export default {
       if (mutation.type === 'deleteAllUnits') {
         store.dispatch('deleteAllCachedUnits');
       }
+      if (mutation.type === 'deleteAllCategories') {
+        store.dispatch('deleteAllCachedCategories');
+      }
       if (mutation.type === 'addAreas') {
         mutation.payload.forEach((area) => {
           store.dispatch('createCachedArea', area);
@@ -66,6 +70,11 @@ export default {
       if (mutation.type === 'addUnits') {
         mutation.payload.forEach((unit) => {
           store.dispatch('createCachedUnit', unit);
+        });
+      }
+      if (mutation.type === 'addCategories') {
+        mutation.payload.forEach((cat) => {
+          store.dispatch('createCachedCategory', cat);
         });
       }
     });

--- a/src/vue-plugins/websql/index.js
+++ b/src/vue-plugins/websql/index.js
@@ -12,6 +12,7 @@ export default {
         store.commit('clearAreas');
         store.commit('clearUnits');
         store.commit('clearCategories');
+        store.dispatch('loadCachedLogs');
         store.dispatch('loadCachedAssets');
         store.dispatch('loadCachedAreas');
         store.dispatch('loadCachedUnits');

--- a/src/vue-plugins/websql/module.js
+++ b/src/vue-plugins/websql/module.js
@@ -216,7 +216,6 @@ export default {
     createCachedCategory(_, newCat) {
       const tableName = 'category';
       const key = 'tid';
-      console.log('CREATING CATEGORY IN DB: ', newCat);
       openDatabase() // eslint-disable-line no-use-before-define
         .then(db => makeTable(db, tableName, newCat, key)) // eslint-disable-line no-use-before-define, max-len
         .then(tx => saveRecord(tx, tableName, newCat)); // eslint-disable-line no-use-before-define, max-len
@@ -243,7 +242,6 @@ export default {
         openDatabase() // eslint-disable-line no-use-before-define
           .then(db => getRecords(db, 'category')) // eslint-disable-line no-use-before-define
           .then((results) => {
-            console.log('GETTING CATEGORIES FROM DB: ', results);
             commit('updateCategoriesFromCache', results);
             resolve();
           })

--- a/src/vue-plugins/websql/module.js
+++ b/src/vue-plugins/websql/module.js
@@ -213,6 +213,44 @@ export default {
       });
     },
 
+    createCachedCategory(_, newCat) {
+      const tableName = 'category';
+      const key = 'tid';
+      console.log('CREATING CATEGORY IN DB: ', newCat);
+      openDatabase() // eslint-disable-line no-use-before-define
+        .then(db => makeTable(db, tableName, newCat, key)) // eslint-disable-line no-use-before-define, max-len
+        .then(tx => saveRecord(tx, tableName, newCat)); // eslint-disable-line no-use-before-define, max-len
+    },
+
+    updateCachedCategory(context, cat) {
+      const table = 'category';
+      const key = 'tid';
+      openDatabase() // eslint-disable-line no-use-before-define
+        .then(db => getTX(db, table, key)) // eslint-disable-line no-use-before-define
+        .then(tx => saveRecord(tx, table, cat)); // eslint-disable-line no-use-before-define, max-len
+    },
+
+    deleteAllCachedCategories() {
+      openDatabase() // eslint-disable-line no-use-before-define
+        .then(db => getTX(db, 'category')) // eslint-disable-line no-use-before-define
+        .then(tx => dropTable(tx, 'category')) // eslint-disable-line no-use-before-define
+        .then(console.log) // eslint-disable-line no-console
+        .catch(console.error); // eslint-disable-line no-console
+    },
+
+    loadCachedCategories({ commit }) {
+      return new Promise((resolve, reject) => {
+        openDatabase() // eslint-disable-line no-use-before-define
+          .then(db => getRecords(db, 'category')) // eslint-disable-line no-use-before-define
+          .then((results) => {
+            console.log('GETTING CATEGORIES FROM DB: ', results);
+            commit('updateCategoriesFromCache', results);
+            resolve();
+          })
+          .catch(reject);
+      });
+    },
+
   },
 };
 


### PR DESCRIPTION
This gets categories from the server, shows the categories associated with logs, allows adding and deletion of categories, and adds new logs with categories to the server, and modifies existing logs with categories.  I've tested it in the dev server and an Android build.

P.S. App performance in Android is now waaaaay snappier, thanks to @jgaehring  recent improvements to how we pull data from the DB!!