### PR TITLE
Categories UI

### DIFF
--- a/config.ios.xml
+++ b/config.ios.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<widget id="org.farmos.app" version="0.3.8" xmlns="http://www.w3.org/ns/widgets" xmlns:cdv="http://cordova.apache.org/ns/1.0">
+<widget id="org.farmos.app" version="0.3.9" xmlns="http://www.w3.org/ns/widgets" xmlns:cdv="http://cordova.apache.org/ns/1.0">
     <name>farmOS</name>
     <description>
 				A native front-end app for farmOS.

--- a/config.xml
+++ b/config.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<widget id="org.farmos.app" version="0.3.8" xmlns="http://www.w3.org/ns/widgets" xmlns:cdv="http://cordova.apache.org/ns/1.0">
+<widget id="org.farmos.app" version="0.3.9" xmlns="http://www.w3.org/ns/widgets" xmlns:cdv="http://cordova.apache.org/ns/1.0">
     <name>farmOS</name>
     <description>
 				A native front-end app for farmOS.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "farmos-client",
-  "version": "0.3.8",
+  "version": "0.3.9",
   "description": "Client app for farmOS!",
   "author": "farmOS team",
   "license": "GPLv3",

--- a/src/client/components/EditLog.vue
+++ b/src/client/components/EditLog.vue
@@ -49,9 +49,10 @@
         </div>
       </div>
 
-      <div class="form-item form-group">
-        <label for="log-categories">Log Categories</label>
+      <div id="categories" class="form-item form-group">
+        <label for="log-categories" id="categories-label">Log Categories</label>
         <select-box
+          small
           v-for="cat in categories"
           :id="`category-${cat.tid}-${cat.name}`"
           :selected="logs[currentLogIndex].log_category.data.some(_cat => cat.tid === _cat.id)"
@@ -782,6 +783,16 @@ export default {
 
   .remove-list-item {
     float: right;
+  }
+
+  #categories {
+    display: flex;
+    flex-flow: row wrap;
+    justify-content: space-between;
+  }
+
+  #categories-label {
+    flex: 1 0 100%;
   }
 
 </style>

--- a/src/client/components/EditLog.vue
+++ b/src/client/components/EditLog.vue
@@ -49,30 +49,19 @@
         </div>
       </div>
 
-      <div class="form-item form-item-name form-group">
-        <label for="type" class="control-label ">Log Categories</label>
-        <div class="input-group">
-          <select
-            @input="addCategory($event.target.value)"
-            class="custom-select col-sm-3 ">
-              <option
-                v-for="cat in categories"
-                :value="cat.tid">
-                {{ (cat) ? cat.name : '' }}
-              </option>
-          </select>
-          <ul v-if="logs[currentLogIndex].log_category.data.length > 0" class="list-group">
-            <li
-              v-for="(cat, i) in logs[currentLogIndex].log_category.data"
-              v-bind:key="`log-${i}-${Math.floor(Math.random() * 1000000)}`"
-              class="list-group-item">
-              {{ (categoryNames.length > 0) ? categoryNames[i] : '' }}
-              <span class="remove-list-item" @click="removeCategory(i)">
-                &#x2715;
-              </span>
-            </li>
-          </ul>
-        </div>
+      <div class="form-item form-group">
+        <label for="log-categories">Log Categories</label>
+        <select-box
+          v-for="cat in categories"
+          :id="`category-${cat.tid}-${cat.name}`"
+          :selected="logs[currentLogIndex].log_category.data.some(_cat => cat.tid === _cat.id)"
+          :label="cat.name"
+          :key="`category-${cat.tid}-${cat.name}`"
+          @input="
+            $event
+            ? addCategory(cat.tid)
+            : removeCategory(logs[currentLogIndex].log_category.data.findIndex(_cat => cat.tid === _cat.id))"
+          />
       </div>
 
       <div class="form-item form-item-name form-group">
@@ -385,6 +374,7 @@
 import Autocomplete from './Autocomplete';
 import IconSpinner from '../../icons/icon-spinner.vue'; // eslint-disable-line import/extensions
 import ToggleCheck from './ToggleCheck.vue';
+import SelectBox from './SelectBox.vue';
 
 export default {
   name: 'EditLog',
@@ -392,6 +382,7 @@ export default {
     Autocomplete,
     IconSpinner,
     ToggleCheck,
+    SelectBox,
   },
 
   data() {

--- a/src/client/components/EditLog.vue
+++ b/src/client/components/EditLog.vue
@@ -51,9 +51,11 @@
 
       <div id="categories" class="form-item form-group">
         <label for="log-categories" id="categories-label">Log Categories</label>
+        <p v-if="!showAllCategories && logs[currentLogIndex].log_category.data.length < 1">No categories selected</p>
         <select-box
           small
           v-for="cat in categories"
+          v-if="showAllCategories || logs[currentLogIndex].log_category.data.some(_cat => cat.tid === _cat.id)"
           :id="`category-${cat.tid}-${cat.name}`"
           :selected="logs[currentLogIndex].log_category.data.some(_cat => cat.tid === _cat.id)"
           :label="cat.name"
@@ -63,6 +65,14 @@
             ? addCategory(cat.tid)
             : removeCategory(logs[currentLogIndex].log_category.data.findIndex(_cat => cat.tid === _cat.id))"
           />
+        <div class="show-hide">
+          <div v-if="!showAllCategories" @click="showAllCategories = !showAllCategories">
+            <p><icon-expand-more/>Show More</p>
+          </div>
+          <div v-if="showAllCategories" @click="showAllCategories = !showAllCategories">
+            <p><icon-expand-less/>Show Less</p>
+          </div>
+        </div>
       </div>
 
       <div class="form-item form-item-name form-group">
@@ -373,6 +383,8 @@
 
 <script>
 import Autocomplete from './Autocomplete';
+import IconExpandLess from '../../icons/icon-expand-less.vue'; // eslint-disable-line import/extensions
+import IconExpandMore from '../../icons/icon-expand-more.vue'; // eslint-disable-line import/extensions
 import IconSpinner from '../../icons/icon-spinner.vue'; // eslint-disable-line import/extensions
 import ToggleCheck from './ToggleCheck.vue';
 import SelectBox from './SelectBox.vue';
@@ -381,6 +393,8 @@ export default {
   name: 'EditLog',
   components: {
     Autocomplete,
+    IconExpandLess,
+    IconExpandMore,
     IconSpinner,
     ToggleCheck,
     SelectBox,
@@ -394,6 +408,7 @@ export default {
       addedArea: false,
       isWorking: false,
       existingLog: false,
+      showAllCategories: false,
       // All types available to the log, with system_name:display name as key:value
       logTypes: {
         farm_observation: 'Observation',
@@ -793,6 +808,22 @@ export default {
 
   #categories-label {
     flex: 1 0 100%;
+  }
+
+  #categories p {
+    font-style: italic;
+  }
+
+  .show-hide {
+    flex: 1 0 100%;
+  }
+
+  .show-hide p {
+    font-size: 1rem;
+  }
+
+  .show-hide svg {
+    vertical-align: bottom;
   }
 
 </style>

--- a/src/client/components/FilterLogs.vue
+++ b/src/client/components/FilterLogs.vue
@@ -213,7 +213,7 @@ export default {
     },
     checkChecked(id) {
       return !document.getElementById(id).checked;
-    }
+    },
   },
 };
 </script>

--- a/src/client/components/SelectBox.vue
+++ b/src/client/components/SelectBox.vue
@@ -1,0 +1,51 @@
+<template lang="html">
+  <div class="form-check">
+    <input
+      type="checkbox"
+      :id="id"
+      :name="id"
+      :checked="selected"
+      @input="$emit('click', $event.target.checked)">
+    <label
+      :for="id"
+      @click="$emit('click', checkChecked(id))"
+      :class="{selected: selected}">
+      {{label}}
+    </label>
+  </div>
+</template>
+
+<script>
+export default {
+  props: [
+    'id',
+    'selected',
+    'label'
+  ]
+  methods: {
+    checkChecked(id) {
+      return !document.getElementById(this.id).checked;
+    },
+  }
+}
+</script>
+
+<style lang="css" scoped>
+  input {
+    position: absolute;
+    opacity: 0;
+  }
+
+  label {
+    padding: 1rem;
+    margin: .5rem;
+    border: solid 2px var(--cyan);
+    font-size: 1rem;
+    font-weight: bold;
+  }
+
+  .selected {
+    color: white;
+    background-color: var(--cyan);
+  }
+</style>

--- a/src/client/components/SelectBox.vue
+++ b/src/client/components/SelectBox.vue
@@ -4,11 +4,10 @@
       type="checkbox"
       :id="id"
       :name="id"
-      :checked="selected"
-      @input="$emit('click', $event.target.checked)">
+      :checked="selected">
     <label
       :for="id"
-      @click="$emit('click', checkChecked(id))"
+      @click="$emit('input', checkChecked(id))"
       :class="{selected: selected}">
       {{label}}
     </label>
@@ -21,18 +20,23 @@ export default {
     'id',
     'selected',
     'label'
-  ]
+  ],
   methods: {
     checkChecked(id) {
       return !document.getElementById(this.id).checked;
     },
-  }
+  },
 }
 </script>
 
 <style lang="css" scoped>
+  .form-check {
+    padding: 0;
+  }
+
   input {
     position: absolute;
+    left: -10000px;
     opacity: 0;
   }
 

--- a/src/client/components/SelectBox.vue
+++ b/src/client/components/SelectBox.vue
@@ -8,7 +8,7 @@
     <label
       :for="id"
       @click="$emit('input', checkChecked(id))"
-      :class="{selected: selected}">
+      :class="[{selected: selected}, {small: small}]">
       {{label}}
     </label>
   </div>
@@ -16,11 +16,12 @@
 
 <script>
 export default {
-  props: [
-    'id',
-    'selected',
-    'label'
-  ],
+  props: {
+    id: String,
+    selected: Boolean,
+    label: String,
+    small: Boolean,
+  },
   methods: {
     checkChecked(id) {
       return !document.getElementById(this.id).checked;
@@ -46,6 +47,12 @@ export default {
     border: solid 2px var(--cyan);
     font-size: 1rem;
     font-weight: bold;
+  }
+
+  label.small {
+    padding: .5rem;
+    font-size: .875rem;
+    margin: .25rem;
   }
 
   .selected {

--- a/src/icons/icon-expand-less.vue
+++ b/src/icons/icon-expand-less.vue
@@ -1,0 +1,3 @@
+<template>
+  <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><path d="M12 8l-6 6 1.41 1.41L12 10.83l4.59 4.58L18 14z"/><path d="M0 0h24v24H0z" fill="none"/></svg>
+</template>

--- a/src/icons/icon-expand-more.vue
+++ b/src/icons/icon-expand-more.vue
@@ -1,0 +1,3 @@
+<template>
+  <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><path d="M16.59 8.59L12 13.17 7.41 8.59 6 10l6 6 6-6z"/><path d="M0 0h24v24H0z" fill="none"/></svg>
+</template>


### PR DESCRIPTION
Uses a multiple choice "SelectBox" layout for categories in EditLog, similar to what we're using for FilterLogs, but more condensed and collapsible:

![categories-show-less](https://user-images.githubusercontent.com/5556545/56438214-21106700-62b0-11e9-887b-ac4db812e25b.png)

![categories-show-more](https://user-images.githubusercontent.com/5556545/56438221-240b5780-62b0-11e9-8522-77857380e477.png)
