### PR TITLE
Refactoring sync logic & upgrading farmOS.js to v0.0.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "farmos-client",
-  "version": "0.3.4",
+  "version": "0.4.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -2288,6 +2288,15 @@
         "num2fraction": "^1.2.2",
         "postcss": "^6.0.17",
         "postcss-value-parser": "^3.2.3"
+      }
+    },
+    "axios": {
+      "version": "0.18.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.18.0.tgz",
+      "integrity": "sha1-MtU+SFHv3AoRmTts0AB4nXDAUQI=",
+      "requires": {
+        "follow-redirects": "^1.3.0",
+        "is-buffer": "^1.1.5"
       }
     },
     "babel-code-frame": {
@@ -6223,9 +6232,13 @@
       }
     },
     "farmos": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/farmos/-/farmos-0.0.2.tgz",
-      "integrity": "sha512-g8b60s5W4cIuPUmUhyx7S0ITCobhQVLyqqL1cG8UJKZhTUCT2HHuS/Ga9sfR5ry0uJMUa0dC5GaDfKSPneAshQ=="
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/farmos/-/farmos-0.0.3.tgz",
+      "integrity": "sha512-lKHDs2SzS2X6xL89Dc7P9YRgL9ZIGZk9dj/oPMGTK79qTwA6ptkPngCySkSfBVm3qI2G7mmNkLb6FKDmBHd6Wg==",
+      "requires": {
+        "axios": "^0.18.0",
+        "ramda": "^0.26.1"
+      }
     },
     "fast-deep-equal": {
       "version": "1.0.0",
@@ -6455,7 +6468,6 @@
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.7.0.tgz",
       "integrity": "sha512-m/pZQy4Gj287eNy94nivy5wchN3Kp+Q5WgUPNy5lJSZ3sgkVKSYV/ZChMAQVIgx1SqfZ2zBZtPA2YlXIWxxJOQ==",
-      "dev": true,
       "requires": {
         "debug": "^3.2.6"
       },
@@ -6464,7 +6476,6 @@
           "version": "3.2.6",
           "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
           "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
-          "dev": true,
           "requires": {
             "ms": "^2.1.1"
           }
@@ -6472,8 +6483,7 @@
         "ms": {
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
-          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
-          "dev": true
+          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
         }
       }
     },
@@ -7898,8 +7908,7 @@
     "is-buffer": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
-      "dev": true
+      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
     },
     "is-builtin-module": {
       "version": "1.0.0",
@@ -11694,6 +11703,11 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/quickselect/-/quickselect-1.1.1.tgz",
       "integrity": "sha512-qN0Gqdw4c4KGPsBOQafj6yj/PA6c/L63f6CaZ/DCF/xF4Esu3jVmKLUDYxghFx8Kb/O7y9tI7x2RjTSXwdK1iQ=="
+    },
+    "ramda": {
+      "version": "0.26.1",
+      "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.26.1.tgz",
+      "integrity": "sha512-hLWjpy7EnsDBb0p+Z3B7rPi3GDeRG5ZtiI33kJhTt+ORCd38AbAIjB/9zRIUoeTbE/AVX5ZkU7m6bznsvrf8eQ=="
     },
     "randombytes": {
       "version": "2.0.6",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "cordova-plugin-network-information": "^2.0.1",
     "cordova-plugin-splashscreen": "^5.0.2",
     "cordova-plugin-whitelist": "^1.3.3",
-    "farmos": "0.0.2",
+    "farmos": "0.0.3",
     "moment": "^2.22.2",
     "vue": "^2.5.2",
     "vue-router": "^3.0.1",

--- a/src/client/store/index.js
+++ b/src/client/store/index.js
@@ -124,6 +124,7 @@ const farmModule = {
     name: '',
     url: '',
     logs: [],
+    serverConflicts: [],
     assets: [],
     areas: [],
     currentLogIndex: 0,
@@ -160,6 +161,10 @@ const farmModule = {
     addEquipment(state, equip) {
       state.equipment = state.equipment.concat(equip);
     },
+    addServerConflicts(state, conflicts) {
+      console.log('running addServerConflicts');
+      state.serverConflicts = state.serverConflicts.concat(conflicts);
+    },
     /*
     updateUnitsFromCache. updateCategoriesFromCache and updateEquipmentFromCache are distinct from
     addUnits because they are NOT hooks for updating units/ cats in the database.  They ONLY add
@@ -183,6 +188,7 @@ const farmModule = {
       state.currentLogIndex = state.logs.push(newLog) - 1;
     },
     // This is called when new logs from the server are added
+    // FIXME: Leaky abstraction; shouldn't have server/db details here
     addLogFromServer(state, newLog) {
       const newIndex = state.logs.push(newLog) - 1;
       this.dispatch('serverLogToDb', { index: newIndex, log: newLog });

--- a/src/client/store/index.js
+++ b/src/client/store/index.js
@@ -124,7 +124,6 @@ const farmModule = {
     name: '',
     url: '',
     logs: [],
-    serverConflicts: [],
     assets: [],
     areas: [],
     currentLogIndex: 0,
@@ -160,10 +159,6 @@ const farmModule = {
     },
     addEquipment(state, equip) {
       state.equipment = state.equipment.concat(equip);
-    },
-    addServerConflicts(state, conflicts) {
-      console.log('running addServerConflicts');
-      state.serverConflicts = state.serverConflicts.concat(conflicts);
     },
     /*
     updateUnitsFromCache. updateCategoriesFromCache and updateEquipmentFromCache are distinct from

--- a/src/utils/makeLog.js
+++ b/src/utils/makeLog.js
@@ -37,6 +37,7 @@ const makeLogFactory = (src, dest) => {
       images = { changed: null, data: [] },
       done = { changed: null, data: true },
       isCachedLocally = false,
+      isReadyToSync = false,
       wasPushedToServer = false,
       remoteUri = '',
       asset = { changed: null, data: [] }, // eslint-disable-line camelcase
@@ -66,6 +67,7 @@ const makeLogFactory = (src, dest) => {
           // Use JSON.parse() to convert strings back to booleans
           done: { data: JSON.parse(done.data), changed: done.changed },
           isCachedLocally: JSON.parse(isCachedLocally), // eslint-disable-line max-len
+          isReadyToSync: JSON.parse(isReadyToSync), // eslint-disable-line max-len
           wasPushedToServer: JSON.parse(wasPushedToServer), // eslint-disable-line max-len
           remoteUri,
           asset: { data: parseObjects(asset.data), changed: asset.changed }, // eslint-disable-line no-use-before-define, max-len

--- a/src/vue-plugins/http/index.js
+++ b/src/vue-plugins/http/index.js
@@ -6,7 +6,9 @@ import module from './module';
 */
 function syncReducer(indices, curLog, curIndex) {
   // Sync all logs to the server; those originally from server will have id fields
-  if (curLog.isReadyToSync !== undefined && JSON.parse(curLog.isReadyToSync) && !JSON.parse(curLog.wasPushedToServer)) { // eslint-disable-line max-len
+  if (curLog.isReadyToSync !== undefined
+    && JSON.parse(curLog.isReadyToSync)
+    && !JSON.parse(curLog.wasPushedToServer)) {
     return indices.concat(curIndex);
   }
   return indices;

--- a/src/vue-plugins/http/module.js
+++ b/src/vue-plugins/http/module.js
@@ -159,127 +159,24 @@ export default {
       return farm().log.get(rootState.shell.settings.logImportFilters)
         .then((res) => {
           console.log('Response returned: ', res);
-          // See whether logs are new, or currently in the store
-          // If res is a single log, check vs current, run through the logFactory and call addLog
-          // If res is multiple, check each vs current, run through logFactory and call addLogs
-          // Returns the log index number as logIndex if the log is present; null if not
-          /*
-          Logs from the server are either saved as new (with isReadyToSync false)
-          Used to over-write local logs (with isReadyToSync fasle)
-          OR, if the local log has been modified since the last sync, a notification
-          is thrown, and the user selects whether to over-write or sync local to server
-          */
 
-          // Process each log on its way from the server to the logFactory
-          function processLog(log) {
-            const checkStatus = checkLog(log, allLogs, syncDate); // eslint-disable-line no-use-before-define, max-len
-            /*
-            If the log is not present locally, add it.
-            If the log is present locally, but has not been changed since the last sync,
-            update it with the new version from the server
-            If the log is present locally and has been changed, check log.changed from the server
-            against the changed property of each log attribute
-             - If any attribute has been changed more recently than the server log, keep it
-             - Otherwise take changes from the server
-            */
-            if (checkStatus.localId === null) {
-              commit('addLogFromServer',
-                makeLog.fromServer({
-                  ...log,
-                  wasPushedToServer: true,
-                  // Trying to make isReady..
-                  isReadyToSync: false,
-                  done: (parseInt(log.done, 10) === 1),
-                }));
-            }
-            if (!checkStatus.localChange && checkStatus.localId !== null && checkStatus.serverChange) { // eslint-disable-line max-len
-              // Update the log with all data from the server
-              const updateParams = {
-                index: checkStatus.storeIndex,
-                log: makeLog.fromServer({
-                  ...log,
-                  wasPushedToServer: true,
-                  isReadyToSync: false,
-                  local_id: checkStatus.localId,
-                  done: (parseInt(log.done, 10) === 1),
-                }),
-              };
-              commit('updateLogFromServer', updateParams);
-            }
-            if (checkStatus.localChange
-              && checkStatus.localId !== null
-              && checkStatus.serverChange) {
-              /*
-              Replace properties of the local log that have not been modified since
-              the last sync with data from the server.
-              For properties that have been completed since the sync date,
-              Present choice to retain either the log or the server version
-              */
-              const storeLog = checkStatus.log;
-              const servLogBuilder = {};
-              const locLogBuilder = {};
-              const serverConflicts = {};
-
-              console.log('There may be conflicts...');
-              /*
-              We compare changed dates for local log properties against the date of last sync.
-              madeFromServer is used as a source
-              for building the merged log, to keep formatting consistent
-              */
-              const madeFromServer = makeLog.fromServer({ ...log });
-              Object.keys(storeLog).forEach((key) => {
-                if (storeLog[key].changed && storeLog[key].changed !== null) {
-                  // TODO: Would it be better to compare against madeFromServer.changed
-                  if (+storeLog[key].changed < +syncDate) {
-                    servLogBuilder[key] = madeFromServer[key];
-                  } else {
-                    locLogBuilder[key] = storeLog[key];
-                    serverConflicts[key] = madeFromServer[key];
-                  }
-                }
-              });
-              /*
-              This is where we can optionally throw a warning about log attributes
-              that have been changed since last sync on both the app and the server.
-               - If retaining local field changes, run the following uncommented code
-               - If discarding local field changes, run this commented code
-               const updateParams = {
-                 index: checkStatus.storeIndex,
-                 log: makeLog.fromServer({
-                   ...log,
-                   wasPushedToServer: true,
-                   isReadyToSync: false,
-                   local_id: checkStatus.localId,
-                 }),
-               };
-               commit('updateLogFromServer', updateParams);
-              */
-              if (locLogBuilder !== {}) {
-                console.log('locLogBuilder is not empty', serverConflicts);
-                const updateParams = {
-                  index: checkStatus.storeIndex,
-                  log: makeLog.toStore({
-                    ...locLogBuilder,
-                    ...servLogBuilder,
-                    wasPushedToServer: false,
-                    local_id: checkStatus.localId,
-                    id: log.id,
-                    done: (parseInt(log.done, 10) === 1),
-                  }),
-                };
-                updateParams.log.isReadyToSync = true;
-                commit('updateLogFromServer', updateParams);
-                commit('addServerConflicts', serverConflicts);
-              }
-            }
-          }
           // Process one or more logs
           if (res.list) {
-            res.list.forEach(log => processLog(log));
+            console.log('Response contains list');
+            res.list.forEach((log) => {
+              const checkStatus = checkLog(log, allLogs, syncDate); // eslint-disable-line no-use-before-define, max-len
+              processLog(log, checkStatus, syncDate, commit); // eslint-disable-line no-use-before-define, max-len
+            });
           } else if (Array.isArray(res)) {
-            res.forEach(log => processLog(log));
+            console.log('Response does not contain list');
+            res.forEach((log) => {
+              const checkStatus = checkLog(log, allLogs, syncDate); // eslint-disable-line no-use-before-define, max-len
+              processLog(log, checkStatus, syncDate, commit); // eslint-disable-line no-use-before-define, max-len
+            });
           } else {
-            processLog(res);
+            console.log('Response is a single log');
+            const checkStatus = checkLog(res, allLogs, syncDate); // eslint-disable-line no-use-before-define, max-len
+            processLog(res, checkStatus, syncDate, commit); // eslint-disable-line no-use-before-define, max-len
           }
         })
         .catch(err => err);
@@ -319,4 +216,107 @@ function checkLog(serverLog, allLogs, syncDate) {
     }
   });
   return logStatus;
+}
+
+// Process each log on its way from the server to the logFactory
+function processLog(log, checkStatus, syncDate, commit) {
+  /*
+  If the log is not present locally, add it.
+  If the log is present locally, but has not been changed since the last sync,
+  update it with the new version from the server
+  If the log is present locally and has been changed, check log.changed from the server
+  against the changed property of each log attribute
+   - If any attribute has been changed more recently than the server log, keep it
+   - Otherwise take changes from the server
+  */
+  if (checkStatus.localId === null) {
+    commit('addLogFromServer',
+      makeLog.fromServer({
+        ...log,
+        wasPushedToServer: true,
+        // Trying to make isReady..
+        isReadyToSync: false,
+        done: (parseInt(log.done, 10) === 1),
+      }));
+  }
+  if (!checkStatus.localChange && checkStatus.localId !== null && checkStatus.serverChange) { // eslint-disable-line max-len
+    // Update the log with all data from the server
+    const updateParams = {
+      index: checkStatus.storeIndex,
+      log: makeLog.fromServer({
+        ...log,
+        wasPushedToServer: true,
+        isReadyToSync: false,
+        local_id: checkStatus.localId,
+        done: (parseInt(log.done, 10) === 1),
+      }),
+    };
+    commit('updateLogFromServer', updateParams);
+  }
+  if (checkStatus.localChange
+    && checkStatus.localId !== null
+    && checkStatus.serverChange) {
+    /*
+    Replace properties of the local log that have not been modified since
+    the last sync with data from the server.
+    For properties that have been completed since the sync date,
+    Present choice to retain either the log or the server version
+    */
+    const storeLog = checkStatus.log;
+    const servLogBuilder = {};
+    const locLogBuilder = {};
+    const serverConflicts = {};
+
+    console.log('There may be conflicts...');
+    /*
+    We compare changed dates for local log properties against the date of last sync.
+    madeFromServer is used as a source
+    for building the merged log, to keep formatting consistent
+    */
+    const madeFromServer = makeLog.fromServer({ ...log });
+    Object.keys(storeLog).forEach((key) => {
+      if (storeLog[key].changed && storeLog[key].changed !== null) {
+        // TODO: Would it be better to compare against madeFromServer.changed
+        if (+storeLog[key].changed < +syncDate) {
+          servLogBuilder[key] = madeFromServer[key];
+        } else {
+          locLogBuilder[key] = storeLog[key];
+          serverConflicts[key] = madeFromServer[key];
+        }
+      }
+    });
+    /*
+    This is where we can optionally throw a warning about log attributes
+    that have been changed since last sync on both the app and the server.
+     - If retaining local field changes, run the following uncommented code
+     - If discarding local field changes, run this commented code
+     const updateParams = {
+       index: checkStatus.storeIndex,
+       log: makeLog.fromServer({
+         ...log,
+         wasPushedToServer: true,
+         isReadyToSync: false,
+         local_id: checkStatus.localId,
+       }),
+     };
+     commit('updateLogFromServer', updateParams);
+    */
+    if (locLogBuilder !== {}) {
+      console.log('locLogBuilder is not empty', serverConflicts);
+      const updateParams = {
+        index: checkStatus.storeIndex,
+        log: makeLog.toStore({
+          ...locLogBuilder,
+          ...servLogBuilder,
+          wasPushedToServer: false,
+          local_id: checkStatus.localId,
+          id: log.id,
+          done: (parseInt(log.done, 10) === 1),
+        }),
+      };
+      updateParams.log.isReadyToSync = true;
+      commit('updateLogFromServer', updateParams);
+      commit('addServerConflicts', serverConflicts);
+    }
+  }
 }

--- a/src/vue-plugins/http/module.js
+++ b/src/vue-plugins/http/module.js
@@ -14,7 +14,7 @@ export default {
       return farm().area.get().then((res) => {
         // If a successful response is received, delete and replace all areas
         commit('deleteAllAreas');
-        const areas = res.map(({ tid, name, geofield }) => ({ tid, name, geofield })); // eslint-disable-line camelcase, max-len
+        const areas = res.list.map(({ tid, name, geofield }) => ({ tid, name, geofield })); // eslint-disable-line camelcase, max-len
         commit('addAreas', areas);
       }).catch((err) => { throw err; });
     },
@@ -22,7 +22,7 @@ export default {
       return farm().asset.get().then((res) => {
         // If a successful response is received, delete and replace all assets
         commit('deleteAllAssets');
-        const assets = res.map(({ id, name, type }) => ({ id, name, type }));
+        const assets = res.list.map(({ id, name, type }) => ({ id, name, type }));
         commit('addAssets', assets);
       }).catch((err) => { throw err; });
     },
@@ -54,7 +54,7 @@ export default {
       }
       return farm().asset.get().then((res) => {
         commit('deleteAllEquipment');
-        const assets = res.map(({ id, name, type }) => ({ id, name, type })); // eslint-disable-line camelcase, max-len
+        const assets = res.list.map(({ id, name, type }) => ({ id, name, type })); // eslint-disable-line camelcase, max-len
         const equipment = getEquip(assets);
         commit('addEquipment', equipment);
       }).catch((err) => { throw err; });
@@ -157,7 +157,7 @@ export default {
       const allLogs = rootState.farm.logs;
       return farm().log.get(rootState.shell.settings.logImportFilters)
         .then((res) => {
-          res.forEach((log) => {
+          res.list.forEach((log) => {
             const checkStatus = checkLog(log, allLogs, syncDate); // eslint-disable-line no-use-before-define, max-len
             if (checkStatus.serverChange) {
               const mergedLog = processLog(log, checkStatus, syncDate); // eslint-disable-line no-use-before-define, max-len


### PR DESCRIPTION
These changes primarily refactor the syncing logic. It makes the core functions of the `getServerLogs` action into reusable, standalone functions, so that they can be more easily reused. This will be necessary to address #198. I anticipate more refactoring to be done in support of that issue, but for now we're at a pretty stable point and so can safely merge into master.

The primary reason for merging this in now is that this branch also includes an upgrade to v0.0.3 of the farmOS.js library. This change probably should have happened on the master branch, but I needed the upgrade in order to clean up some of the syncing logic.