### PR TITLE
Run GET request for logs excluded by import filters

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6232,9 +6232,9 @@
       }
     },
     "farmos": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/farmos/-/farmos-0.0.3.tgz",
-      "integrity": "sha512-lKHDs2SzS2X6xL89Dc7P9YRgL9ZIGZk9dj/oPMGTK79qTwA6ptkPngCySkSfBVm3qI2G7mmNkLb6FKDmBHd6Wg==",
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/farmos/-/farmos-0.0.4.tgz",
+      "integrity": "sha512-mRP+1F7qzb/h3OhkBnk9lR/iMEXGQTEMxYk0Yr9gmvICxubzsQe78nfMewzcVpdTmSdj1bpQoETefnrAIx3BIg==",
       "requires": {
         "axios": "^0.18.0",
         "ramda": "^0.26.1"

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "cordova-plugin-network-information": "^2.0.1",
     "cordova-plugin-splashscreen": "^5.0.2",
     "cordova-plugin-whitelist": "^1.3.3",
-    "farmos": "0.0.3",
+    "farmos": "0.0.4",
     "moment": "^2.22.2",
     "vue": "^2.5.2",
     "vue-router": "^3.0.1",

--- a/src/vue-plugins/http/module.js
+++ b/src/vue-plugins/http/module.js
@@ -272,7 +272,6 @@ function processLog(log, checkStatus, syncDate) {
   const storeLog = checkStatus.log;
   const servLogBuilder = {};
   const locLogBuilder = {};
-  const serverConflicts = {};
 
   /*
   We compare changed dates for local log properties against the date of last sync.
@@ -282,12 +281,10 @@ function processLog(log, checkStatus, syncDate) {
   const madeFromServer = makeLog.fromServer(log);
   Object.keys(storeLog).forEach((key) => {
     if (storeLog[key].changed && storeLog[key].changed !== null) {
-      // TODO: Would it be better to compare against madeFromServer.changed
       if (+storeLog[key].changed < +syncDate) {
         servLogBuilder[key] = madeFromServer[key];
       } else {
         locLogBuilder[key] = storeLog[key];
-        serverConflicts[key] = madeFromServer[key];
       }
     }
   });


### PR DESCRIPTION
I went with a slightly different approach than I outlined in https://github.com/farmOS/farmOS-client/issues/198#issuecomment-489447803. Instead I just chained the requests together and ran a filter against all the logs that had already been checked and merged.

This PR also upgrades farmOS.js to v0.0.4, which was necessary to pass an array of log id's into `farm.log.get()`.

This resolves #198.