### PR TITLE
Login on sync error

### DIFF
--- a/src/vue-plugins/http/index.js
+++ b/src/vue-plugins/http/index.js
@@ -67,10 +67,11 @@ export default {
           */
           store.commit('updateAllLogs', logSyncer);
           // Get and process logs from the server in httpModule
-          store.dispatch('getServerLogs')
+          store.dispatch('getServerLogs', { router })
             .then(() => {
               // Save the current time as the most recent syncDate
               localStorage.setItem('syncDate', (Date.now() / 1000).toFixed(0));
+              console.log('GETSERVERLOGS COMPLETED');
               // After getServerLogs finishes, we send logs with isReadyToSync true to the server
               const indices = store.state.farm.logs.reduce(syncReducer, []);
               store.dispatch('sendLogs', { indices, router });

--- a/src/vue-plugins/http/index.js
+++ b/src/vue-plugins/http/index.js
@@ -29,8 +29,8 @@ export default {
       after: (action) => {
         if (action.type === 'forceSyncAssetsAndAreas') {
           if (localStorage.getItem('host') !== null) {
-            store.dispatch('updateAssets', router);
-            store.dispatch('updateAreas', router);
+            store.dispatch('updateAssets');
+            store.dispatch('updateAreas');
             return;
           }
           router.push('/login');
@@ -59,16 +59,16 @@ export default {
         // This means a call to the server on app load.
         // *** I think it would be better to retrieve only when the sync button is tapped
         if (action.type === 'loadCachedAssets') {
-          store.dispatch('updateAssets', router);
+          store.dispatch('updateAssets');
         }
         if (action.type === 'loadCachedAreas') {
-          store.dispatch('updateAreas', router);
+          store.dispatch('updateAreas');
         }
         // Update units, categories and equipment from server ONLY when sync button is tapped
         if (action.type === 'sendLogs') {
-          store.dispatch('updateUnits', router)
-            .then(store.dispatch('updateCategories', router))
-            .then(store.dispatch('updateEquipment', router));
+          store.dispatch('updateUnits')
+            .then(store.dispatch('updateCategories'))
+            .then(store.dispatch('updateEquipment'));
         }
       },
     });

--- a/src/vue-plugins/http/module.js
+++ b/src/vue-plugins/http/module.js
@@ -47,39 +47,39 @@ function handleSyncError(error, index, rootState, router, commit) {
 
 export default {
   actions: {
-    updateAreas({ commit, rootState }, router) {
+    updateAreas({ commit }) {
       return farm().area.get().then((res) => {
         // If a successful response is received, delete and replace all areas
         commit('deleteAllAreas');
         const areas = res.list.map(({ tid, name, geofield }) => ({ tid, name, geofield })); // eslint-disable-line camelcase, max-len
         commit('addAreas', areas);
-      }).catch(err => handleSyncError(err, null, rootState, router, commit));
+      });
     },
-    updateAssets({ commit, rootState }, router) {
+    updateAssets({ commit }) {
       return farm().asset.get().then((res) => {
         // If a successful response is received, delete and replace all assets
         commit('deleteAllAssets');
         const assets = res.list.map(({ id, name, type }) => ({ id, name, type }));
         commit('addAssets', assets);
-      }).catch(err => handleSyncError(err, null, rootState, router, commit));
+      });
     },
-    updateUnits({ commit, rootState }, router) {
+    updateUnits({ commit }) {
       // Return units only.
       return farm().term.get('farm_quantity_units').then((res) => {
         commit('deleteAllUnits');
         const units = res.list.map(({ tid, name }) => ({ tid, name }));
         commit('addUnits', units);
-      }).catch(err => handleSyncError(err, null, rootState, router, commit));
+      });
     },
-    updateCategories({ commit, rootState }, router) {
+    updateCategories({ commit }) {
       // Return categories only.
       return farm().term.get('farm_log_categories').then((res) => {
         commit('deleteAllCategories');
         const cats = res.list.map(({ tid, name }) => ({ tid, name }));
         commit('addCategories', cats);
-      }).catch(err => handleSyncError(err, null, rootState, router, commit));
+      });
     },
-    updateEquipment({ commit, rootState }, router) {
+    updateEquipment({ commit }) {
       function getEquip(assets) {
         const equip = [];
         assets.forEach((asset) => {
@@ -94,7 +94,7 @@ export default {
         const assets = res.list.map(({ id, name, type }) => ({ id, name, type })); // eslint-disable-line camelcase, max-len
         const equipment = getEquip(assets);
         commit('addEquipment', equipment);
-      }).catch(err => handleSyncError(err, null, rootState, router, commit));
+      });
     },
 
     // SEND LOGS TO SERVER (step 2 of sync)

--- a/src/vue-plugins/login/module.js
+++ b/src/vue-plugins/login/module.js
@@ -87,7 +87,7 @@ export default {
     },
 
     logout() {
-      lazyFarm().logout().then((res) => {
+      lazyFarm().logout().then(() => {
         // Currently farmOS.js returns no response to logout requests
       });
     },

--- a/src/vue-plugins/login/module.js
+++ b/src/vue-plugins/login/module.js
@@ -87,7 +87,7 @@ export default {
     },
 
     logout() {
-      lazyFarm().logout().then(() => {
+      lazyFarm().logout().then((res) => {
         // Currently farmOS.js returns no response to logout requests
       });
     },


### PR DESCRIPTION
This adds a working error handler for the sendLog and getServerLog actions.  Users are routed to the login view in the case of 401, 403 and 404 errors.  Otherwise the error is displayed on screen.  In the case of sendLog errors, the name of the log that failed is also displayed.

This should mean that when a users' credientials expire, they will be routed to the login view.  I tested this by building the app for Android, logging in to a Farmier account, and then changing my account password.  As expected, the app displayed the login view after the password was changed.