### PR TITLE
Enforce format

### DIFF
--- a/src/vue-plugins/http/module.js
+++ b/src/vue-plugins/http/module.js
@@ -158,6 +158,18 @@ export default {
           });
         });
     },
+    // Stop spinner on aborted sync attempts by setting isReadyToSync false
+    unreadyLog({ commit }, index) {
+      commit('updateLogs', {
+        indices: [index],
+        mapper(log) {
+          return makeLog.create({
+            ...log,
+            isReadyToSync: false,
+          });
+        },
+      });
+    },
   },
 };
 


### PR DESCRIPTION
This prevents users from syncing seeding logs that do not contain at least one planting asset.  It uses the criteriaMet function in http:/index

I originally though I would have to block seedings that contained areas, too.  For example, it used to be the case that you could create an observation log, add and area, then change the log type to seeding.  This would generate a sync error, because seedings can't contain areas.  However, the area field is now removed from the local log when the type is changed.  So that turns out not to be necessary!