### PR TITLE
Fix http error handling

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "farmos-client",
-  "version": "0.4.6",
+  "version": "0.4.8",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -3191,6 +3191,14 @@
         "lodash": "^4.17.4",
         "mkdirp": "^0.5.1",
         "source-map-support": "^0.4.15"
+      },
+      "dependencies": {
+        "core-js": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.9.tgz",
+          "integrity": "sha512-HOpZf6eXmnl7la+cUdMnLvUxKNqLUzJvgIziQ0DiF3JwSImNphIqdGqzj6hIKyX04MmV0poclQ7+wjWvxQyR2A==",
+          "dev": true
+        }
       }
     },
     "babel-runtime": {
@@ -3201,6 +3209,14 @@
       "requires": {
         "core-js": "^2.4.0",
         "regenerator-runtime": "^0.11.0"
+      },
+      "dependencies": {
+        "core-js": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.9.tgz",
+          "integrity": "sha512-HOpZf6eXmnl7la+cUdMnLvUxKNqLUzJvgIziQ0DiF3JwSImNphIqdGqzj6hIKyX04MmV0poclQ7+wjWvxQyR2A==",
+          "dev": true
+        }
       }
     },
     "babel-template": {
@@ -4299,7 +4315,7 @@
       "dependencies": {
         "shelljs": {
           "version": "0.5.3",
-          "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.5.3.tgz",
+          "resolved": false,
           "integrity": "sha1-xUmCuZbHbvDB5rWfvcWCX1txMRM="
         }
       }
@@ -4667,11 +4683,10 @@
       "resolved": "https://registry.npmjs.org/cordova-plugin-whitelist/-/cordova-plugin-whitelist-1.3.4.tgz",
       "integrity": "sha512-EYC5eQFVkoYXq39l7tYKE6lEjHJ04mvTmKXxGL7quHLdFPfJMNzru/UYpn92AOfpl3PQaZmou78C7EgmFOwFQQ=="
     },
-    "core-js": {
-      "version": "2.5.3",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.3.tgz",
-      "integrity": "sha1-isw4NFgk8W2DZbfJtCWRaOjtYD4=",
-      "dev": true
+    "core-js-pure": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.2.1.tgz",
+      "integrity": "sha512-+qpvnYrsi/JDeQTArB7NnNc2VoMYLE1YSkziCDHgjexC2KH7OFiGhLUd3urxfyWmNjSwSW7NYXPWHMhuIJx9Ow=="
     },
     "core-util-is": {
       "version": "1.0.2",
@@ -6543,12 +6558,13 @@
       }
     },
     "farmOS-map": {
-      "version": "github:farmOS/farmOS-map#81ccdc23266cdd6d5428dc6d509ef12ea8805702",
-      "from": "github:farmOS/farmOS-map#v0.2.0",
+      "version": "github:farmOS/farmOS-map#581ba233ce48e43c6f6622974a9852862562db02",
+      "from": "github:farmOS/farmOS-map#v0.4.0",
       "requires": {
         "ol": "^5.3.0",
         "ol-geocoder": "^3.3.0",
-        "ol-layerswitcher": "^3.3.0"
+        "ol-layerswitcher": "^3.3.0",
+        "ol-popup": "^4.0.0"
       }
     },
     "farmos": {
@@ -9646,9 +9662,14 @@
       "integrity": "sha512-hpqVw0mCWEUzc7emJyDVl9ovhP84xr2MB5o7pERXQbl2gQIPPRmI1KXGrkVXkyIT3l3hCFKn6ra+/0fa2+CMBA=="
     },
     "ol-layerswitcher": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/ol-layerswitcher/-/ol-layerswitcher-3.3.0.tgz",
-      "integrity": "sha512-/ZFwcsGyjneugZWEItxkwCULix5lpRVJ2d/y+Ydd4r01MTtwMZHPJQMV3Q6ChrKgKtVwjLU7vyBXziLnaIvWsA=="
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/ol-layerswitcher/-/ol-layerswitcher-3.4.0.tgz",
+      "integrity": "sha512-WhCf+UKyJuOIp9DehjhInATaiVK4ic89ZqxMlZ9vfEW1BsQ7Y7hDxoAlqgXtW9FQz2Ch558XIVMBRWfsB7CJ2w=="
+    },
+    "ol-popup": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/ol-popup/-/ol-popup-4.0.0.tgz",
+      "integrity": "sha512-4EMI7+QOAHcPI4RSc2XqEOHgl6922zmk4D1nwuJZsMn3o1qH2IsZg6JggXL+Bm2JmbTQl4dPoZaUZaqSKpm6mw=="
     },
     "on-finished": {
       "version": "2.3.0",
@@ -13762,7 +13783,7 @@
     },
     "strip-eof": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
+      "resolved": "http://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
       "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
       "dev": true
     },

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "cordova-plugin-network-information": "^2.0.2",
     "cordova-plugin-splashscreen": "^5.0.3",
     "cordova-plugin-whitelist": "^1.3.4",
+    "core-js-pure": "^3.2.1",
     "farmOS-map": "farmOS/farmOS-map#v0.4.0",
     "farmos": "0.0.6",
     "moment": "^2.22.2",

--- a/src/client/components/EditLog.vue
+++ b/src/client/components/EditLog.vue
@@ -894,7 +894,7 @@ export default {
       return [];
     },
     areaGeoJSON() {
-      return (process.env.NODE_ENV === 'development') 
+      return (process.env.NODE_ENV === 'development')
         ? 'http://localhost/farm/areas/geojson/all'
         : `${localStorage.getItem('host')}/farm/areas/geojson/all`
     },

--- a/src/client/components/EditLog.vue
+++ b/src/client/components/EditLog.vue
@@ -57,7 +57,8 @@
     For logs currently on the server, display type as text -->
     <div class="form-item form-item-name form-group">
       <label for="type" class="control-label ">Log Type</label>
-      <div class="input-group" v-if="(logs[currentLogIndex].id === undefined)">
+      <!--<div class="input-group" v-if="(logs[currentLogIndex].id === undefined)">-->
+      <div class="input-group">
         <select
           :value="logs[currentLogIndex].type.data"
           @input="updateCurrentLog('type', $event.target.value)"

--- a/src/client/components/EditLog.vue
+++ b/src/client/components/EditLog.vue
@@ -57,8 +57,7 @@
     For logs currently on the server, display type as text -->
     <div class="form-item form-item-name form-group">
       <label for="type" class="control-label ">Log Type</label>
-      <!--<div class="input-group" v-if="(logs[currentLogIndex].id === undefined)">-->
-      <div class="input-group">
+      <div class="input-group" v-if="(logs[currentLogIndex].id === undefined)">
         <select
           :value="logs[currentLogIndex].type.data"
           @input="updateCurrentLog('type', $event.target.value)"

--- a/src/utils/geometry.js
+++ b/src/utils/geometry.js
@@ -8,7 +8,7 @@ function compare(geojson1, geojson2) {
 export function mergeGeometries(wkts) {
   // First, filter out empty strings and return a value if there are less than
   // two values to merge.
-  const validWKTs = wkts.filter(wkt => wkt !== '');
+  const validWKTs = wkts.filter(wkt => !!wkt);
   if (validWKTs.length === 0) {
     return '';
   }

--- a/src/vue-plugins/http/index.js
+++ b/src/vue-plugins/http/index.js
@@ -8,9 +8,6 @@ export default {
 
       This function also enforces the following criteria for specific log types:
         - Seedings must be associated with at least one planting asset
-
-      TODO:
-        - Seedings cannot be associated with an area
     */
     function syncReducer(indices, curLog, curIndex) {
       // Check if criteria for specific log types are met
@@ -57,33 +54,35 @@ export default {
 
     /*
     This handles the custom error type defined in ./module.js, thrown by getServerLogs and sendLogs
-    1 second timeout gives time for all errors to resolve
-    Necessary because Promise.all rejects after the FIRST error is thrown
-    it does not wait for subsequent errors, which are still caught internally by indices.map
-
-    TODO:
-    Implement a polyfill for the new promise.allSettled method, which can catch an array of errors
-    but isn't yet implemented by most browsers https://javascript.info/promise-api
     */
     function handleSyncError(syncError) {
-      setTimeout(() => {
-        // First set all logs to not ready to sync so their spinners stops spinning
-        store.commit('updateAllLogs', log => ({ ...log, isReadyToSync: false }));
-        // Create a message string that we will build out as we go.
-        let errMsg = '';
+      // First set all logs to not ready to sync so their spinners stops spinning
+      store.commit('updateAllLogs', log => ({ ...log, isReadyToSync: false }));
+      // Create a message string that we will build out as we go.
+      let errMsg = '';
+      if (syncError.status.includes(401)
+        || syncError.status.includes(403)
+        || syncError.status.includes(404)) {
+        // Reroute authentication or authorization errors to login page
+        router.push('/login');
+      } else if (syncError.indices.length > 0) {
+        // Build a message from sendLogs errors, which have an index
         syncError.indices.forEach((logIndex, errIndex) => {
           const logName = store.state.farm.logs[logIndex].name.data;
-          if (syncError.http[errIndex].response === undefined) {
-            errMsg += 'Unable to sync because the network is currently unavailable. Please try syncing again later.';
-          } else if (syncError.http[errIndex].response.status === 401
-            || syncError.http[errIndex].response.status === 403
-            || syncError.http[errIndex].response.status === 404) {
-            // Reroute authentication or authorization errors to login page
-            router.push('/login');
+          if (syncError.message.length > 0) {
+            errMsg += `${syncError.status[errIndex]} error while syncing "${logName}": ${syncError.message[errIndex]} <br>`;
           } else {
-            errMsg += `${syncError.http[errIndex].response.status} error while syncing "${logName}": ${syncError.http[errIndex].response.statusText} <br>`;
+            errMsg += `${syncError.status[errIndex]} error while syncing "${logName}" <br>`;
           }
         });
+      } else if (syncError.status.length > 0) {
+        // Build a message from getServerLogs errors, which have no index
+        errMsg += `${syncError.status[0]} error: ${syncError.message[0]} <br>`;
+      } else {
+        errMsg += 'Unable to sync because the network is currently unavailable.';
+      }
+      if (errMsg !== '') {
+        // Display an error if there is message text
         const errorPayload = {
           message: errMsg,
           errorCode: '',
@@ -91,7 +90,7 @@ export default {
           show: true,
         };
         store.commit('logError', errorPayload);
-      }, 1000);
+      }
     }
 
     store.registerModule('http', module);

--- a/src/vue-plugins/http/index.js
+++ b/src/vue-plugins/http/index.js
@@ -113,9 +113,13 @@ export default {
                 localStorage.setItem('syncDate', (Date.now() / 1000).toFixed(0));
                 // After getServerLogs finishes, we send logs with isReadyToSync true to the server
                 const indices = store.state.farm.logs.reduce(syncReducer, []);
-                store.dispatch('sendLogs', indices);
+                return store.dispatch('sendLogs', indices);
               })
+              // Jamie suggested:
+              // .catch(errs => errs.forEach(handleSyncError));
+              // This doesn't seem to work
               .catch(handleSyncError);
+              // This works for errors from getServerLogs, but not from sendLogs
           } else {
             router.push('/login');
           }

--- a/src/vue-plugins/http/index.js
+++ b/src/vue-plugins/http/index.js
@@ -58,10 +58,13 @@ export default {
 
     // This handles the custom error type defined in ./module.js
     function handleSyncError(syncError) {
+      console.log('HTTP/INDEX RECEIVED A SYNCERROR AT INDEX: ', syncError.indices, '\n', syncError);
+      console.log('SYNCERROR LOGS: ', '\n', syncError.indices.reduce((acc, cur) => store.state.farm.logs[cur], ''))
       // First set all logs to not ready to sync so their spinners stops spinning
       store.commit('updateAllLogs', log => ({ ...log, isReadyToSync: false }));
       const logNames = syncError.indices.length > 0
-        ? syncError.indices.reduce((acc, cur) => `${acc}, "${store.state.farm.logs[cur]}"`, '')
+        ? syncError.indices.reduce((acc, cur) => `${store.state.farm.logs[cur].name.data}`, '')
+        //? `${store.state.farm.logs[syncError.indices[0]].name.data}`
         : '';
       // Do something if there's no response object (mostly likely no connection)
       if (syncError.http.response === undefined) {

--- a/src/vue-plugins/http/module.js
+++ b/src/vue-plugins/http/module.js
@@ -93,21 +93,22 @@ export default {
           },
         });
       }
-
-      indices.forEach((index) => { // eslint-disable-line array-callback-return, max-len
+      return Promise.all(indices.map((index) => { // eslint-disable-line array-callback-return
+      // indices.forEach((index) => { // eslint-disable-line array-callback-return, max-len
         // Either send or post logs, depending on whether they originated on the server
         // Logs originating on the server possess an ID field; others do not.
         const newLog = makeLog.toServer(rootState.farm.logs[index]);
-        farm().log.send(newLog, localStorage.getItem('token')) // eslint-disable-line no-use-before-define, max-len
+        return farm().log.send(newLog, localStorage.getItem('token')) // eslint-disable-line no-use-before-define, max-len
           .then(res => handleSyncResponse(res, index))
           // .catch(err => handleSyncError(err, index, rootState, payload.router, commit));
           .catch((err) => {
+            console.log('CAUGHT AN ERROR FROM THE SERVER: ', '\n', err)
             throw new SyncError({
               indices: [index],
               http: err,
             });
           });
-      });
+      }));
     },
 
     // GET LOGS FROM SERVER (step 1 of sync)

--- a/src/vue-plugins/http/module.js
+++ b/src/vue-plugins/http/module.js
@@ -22,174 +22,6 @@ class SyncError extends Error {
   }
 }
 
-export default {
-  actions: {
-    updateAreas({ commit }) {
-      return farm().area.get().then((res) => {
-        // If a successful response is received, delete and replace all areas
-        commit('deleteAllAreas');
-        const areas = res.list.map(({ tid, name, geofield }) => ({ tid, name, geofield })); // eslint-disable-line camelcase, max-len
-        commit('addAreas', areas);
-      });
-    },
-    updateAssets({ commit }) {
-      return farm().asset.get().then((res) => {
-        // If a successful response is received, delete and replace all assets
-        commit('deleteAllAssets');
-        const assets = res.list.map(({ id, name, type }) => ({ id, name, type }));
-        commit('addAssets', assets);
-      });
-    },
-    updateUnits({ commit }) {
-      // Return units only.
-      return farm().term.get('farm_quantity_units').then((res) => {
-        commit('deleteAllUnits');
-        const units = res.list.map(({ tid, name }) => ({ tid, name }));
-        commit('addUnits', units);
-      });
-    },
-    updateCategories({ commit }) {
-      // Return categories only.
-      return farm().term.get('farm_log_categories').then((res) => {
-        commit('deleteAllCategories');
-        const cats = res.list.map(({ tid, name }) => ({ tid, name }));
-        commit('addCategories', cats);
-      });
-    },
-    updateEquipment({ commit }) {
-      function getEquip(assets) {
-        const equip = [];
-        assets.forEach((asset) => {
-          if (asset.type === 'equipment') {
-            equip.push(asset);
-          }
-        });
-        return equip;
-      }
-      return farm().asset.get().then((res) => {
-        commit('deleteAllEquipment');
-        const assets = res.list.map(({ id, name, type }) => ({ id, name, type })); // eslint-disable-line camelcase, max-len
-        const equipment = getEquip(assets);
-        commit('addEquipment', equipment);
-      });
-    },
-
-    // SEND LOGS TO SERVER (step 2 of sync)
-    sendLogs({ commit, rootState }, indices) {
-      // Update logs in the database and local store after send completes
-      function handleSyncResponse(response, index) {
-        commit('updateLogs', {
-          indices: [index],
-          mapper(log) {
-            return makeLog.create({
-              ...log,
-              id: response.id,
-              wasPushedToServer: true,
-              isReadyToSync: false,
-              remoteUri: response.uri,
-            });
-          },
-        });
-      }
-      return Promise.allSettled(
-        indices.map((index) => { // eslint-disable-line array-callback-return
-        // Either send or post logs, depending on whether they originated on the server
-        // Logs originating on the server possess an ID field; others do not.
-          const newLog = makeLog.toServer(rootState.farm.logs[index]);
-          return farm().log.send(newLog, localStorage.getItem('token')); // eslint-disable-line no-use-before-define, max-len
-        }),
-      )
-        .then((promises) => {
-          const errResponses = promises.reduce((errors, promise, arrayIndex) => { // eslint-disable-line consistent-return, array-callback-return, max-len
-            if (promise.status === 'rejected') {
-              // If the API call returns an error, add the index and status to errResponses
-              return errors.push({
-                index: indices[arrayIndex],
-                status: parseInt(promise.reason.message.substr(-3), 10),
-              });
-            } if (promise.status === 'fulfilled') {
-              handleSyncResponse(promise.value, indices[arrayIndex]);
-              return errors;
-            }
-          });
-          if (errResponses.length > 0) {
-            throw new SyncError({
-              responses: errResponses,
-            });
-          }
-        });
-    },
-
-    // GET LOGS FROM SERVER (step 1 of sync)
-    getServerLogs({ commit, rootState }) {
-      const syncDate = localStorage.getItem('syncDate');
-      const allLogs = rootState.farm.logs;
-      return farm().log.get(rootState.shell.settings.logImportFilters)
-        .then(res => (
-          // Returns an array of ids which have already been checked & merged
-          res.list.map((log) => {
-            const checkStatus = checkLog(log, allLogs, syncDate); // eslint-disable-line no-use-before-define, max-len
-            if (checkStatus.serverChange) {
-              const mergedLog = processLog(log, checkStatus, syncDate); // eslint-disable-line no-use-before-define, max-len
-              commit('updateLogFromServer', {
-                index: checkStatus.storeIndex,
-                log: mergedLog,
-              });
-            }
-            if (checkStatus.localId === null) {
-              const mergedLog = processLog(log, checkStatus, syncDate); // eslint-disable-line no-use-before-define, max-len
-              commit('addLogFromServer', mergedLog);
-            }
-            return log.id;
-          })
-        ))
-        // Run a 2nd request for the remaining logs not included in the import filters
-        .then((checkedIds) => {
-          const uncheckedIds = allLogs
-            .filter(log => log.id && !checkedIds.some(checkedId => log.id === checkedId))
-            .map(log => log.id);
-          return farm().log.get(uncheckedIds);
-        })
-        .then((res) => {
-          res.list.forEach((log) => {
-            const checkStatus = checkLog(log, allLogs, syncDate); // eslint-disable-line no-use-before-define, max-len
-            if (checkStatus.serverChange) {
-              const mergedLog = processLog(log, checkStatus, syncDate); // eslint-disable-line no-use-before-define, max-len
-              commit('updateLogFromServer', {
-                index: checkStatus.storeIndex,
-                log: mergedLog,
-              });
-            }
-          });
-        })
-        .catch((err) => {
-          if (err.response) {
-            throw new SyncError({
-              responses: [{
-                status: err.response.status,
-                message: err.response.statusText,
-              }],
-            });
-          } else {
-            throw new SyncError({});
-          }
-        });
-    },
-    // Stop spinner on aborted sync attempts by setting isReadyToSync false
-    unreadyLog({ commit }, index) {
-      commit('updateLogs', {
-        indices: [index],
-        mapper(log) {
-          return makeLog.create({
-            ...log,
-            isReadyToSync: false,
-          });
-        },
-      });
-    },
-  },
-};
-
 function checkLog(serverLog, allLogs, syncDate) {
   // The localLog will be passed as logStatus.log if localChange checks true
   const logStatus = {
@@ -291,3 +123,171 @@ function processLog(log, checkStatus, syncDate) {
     isReadyToSync: true,
   });
 }
+
+export default {
+  actions: {
+    updateAreas({ commit }) {
+      return farm().area.get().then((res) => {
+        // If a successful response is received, delete and replace all areas
+        commit('deleteAllAreas');
+        const areas = res.list.map(({ tid, name, geofield }) => ({ tid, name, geofield }));
+        commit('addAreas', areas);
+      });
+    },
+    updateAssets({ commit }) {
+      return farm().asset.get().then((res) => {
+        // If a successful response is received, delete and replace all assets
+        commit('deleteAllAssets');
+        const assets = res.list.map(({ id, name, type }) => ({ id, name, type }));
+        commit('addAssets', assets);
+      });
+    },
+    updateUnits({ commit }) {
+      // Return units only.
+      return farm().term.get('farm_quantity_units').then((res) => {
+        commit('deleteAllUnits');
+        const units = res.list.map(({ tid, name }) => ({ tid, name }));
+        commit('addUnits', units);
+      });
+    },
+    updateCategories({ commit }) {
+      // Return categories only.
+      return farm().term.get('farm_log_categories').then((res) => {
+        commit('deleteAllCategories');
+        const cats = res.list.map(({ tid, name }) => ({ tid, name }));
+        commit('addCategories', cats);
+      });
+    },
+    updateEquipment({ commit }) {
+      function getEquip(assets) {
+        const equip = [];
+        assets.forEach((asset) => {
+          if (asset.type === 'equipment') {
+            equip.push(asset);
+          }
+        });
+        return equip;
+      }
+      return farm().asset.get().then((res) => {
+        commit('deleteAllEquipment');
+        const assets = res.list.map(({ id, name, type }) => ({ id, name, type }));
+        const equipment = getEquip(assets);
+        commit('addEquipment', equipment);
+      });
+    },
+
+    // SEND LOGS TO SERVER (step 2 of sync)
+    sendLogs({ commit, rootState }, indices) {
+      // Update logs in the database and local store after send completes
+      function handleSyncResponse(response, index) {
+        commit('updateLogs', {
+          indices: [index],
+          mapper(log) {
+            return makeLog.create({
+              ...log,
+              id: response.id,
+              wasPushedToServer: true,
+              isReadyToSync: false,
+              remoteUri: response.uri,
+            });
+          },
+        });
+      }
+      return Promise.allSettled(
+        indices.map((index) => {
+        // Either send or post logs, depending on whether they originated on the server
+        // Logs originating on the server possess an ID field; others do not.
+          const newLog = makeLog.toServer(rootState.farm.logs[index]);
+          return farm().log.send(newLog, localStorage.getItem('token'));
+        }),
+      )
+        .then((promises) => {
+          const errResponses = promises.reduce((errors, promise, arrayIndex) => {
+            if (promise.status === 'rejected') {
+              // If the API call returns an error, add the index and status to errResponses
+              return errors.push({
+                index: indices[arrayIndex],
+                status: parseInt(promise.reason.message.substr(-3), 10),
+              });
+            } if (promise.status === 'fulfilled') {
+              handleSyncResponse(promise.value, indices[arrayIndex]);
+            }
+            return errors;
+          });
+          if (errResponses.length > 0) {
+            throw new SyncError({
+              responses: errResponses,
+            });
+          }
+        });
+    },
+
+    // GET LOGS FROM SERVER (step 1 of sync)
+    getServerLogs({ commit, rootState }) {
+      const syncDate = localStorage.getItem('syncDate');
+      const allLogs = rootState.farm.logs;
+      return farm().log.get(rootState.shell.settings.logImportFilters)
+        .then(res => (
+          // Returns an array of ids which have already been checked & merged
+          res.list.map((log) => {
+            const checkStatus = checkLog(log, allLogs, syncDate);
+            if (checkStatus.serverChange) {
+              const mergedLog = processLog(log, checkStatus, syncDate);
+              commit('updateLogFromServer', {
+                index: checkStatus.storeIndex,
+                log: mergedLog,
+              });
+            }
+            if (checkStatus.localId === null) {
+              const mergedLog = processLog(log, checkStatus, syncDate);
+              commit('addLogFromServer', mergedLog);
+            }
+            return log.id;
+          })
+        ))
+        // Run a 2nd request for the remaining logs not included in the import filters
+        .then((checkedIds) => {
+          const uncheckedIds = allLogs
+            .filter(log => log.id && !checkedIds.some(checkedId => log.id === checkedId))
+            .map(log => log.id);
+          return farm().log.get(uncheckedIds);
+        })
+        .then((res) => {
+          res.list.forEach((log) => {
+            const checkStatus = checkLog(log, allLogs, syncDate);
+            if (checkStatus.serverChange) {
+              const mergedLog = processLog(log, checkStatus, syncDate);
+              commit('updateLogFromServer', {
+                index: checkStatus.storeIndex,
+                log: mergedLog,
+              });
+            }
+          });
+        })
+        .catch((err) => {
+          if (err.response) {
+            throw new SyncError({
+              responses: [{
+                status: err.response.status,
+                message: err.response.statusText,
+              }],
+            });
+          } else {
+            throw new SyncError({});
+          }
+        });
+    },
+    // Stop spinner on aborted sync attempts by setting isReadyToSync false
+    unreadyLog({ commit }, index) {
+      commit('updateLogs', {
+        indices: [index],
+        mapper(log) {
+          return makeLog.create({
+            ...log,
+            isReadyToSync: false,
+          });
+        },
+      });
+    },
+  },
+};

--- a/src/vue-plugins/http/module.js
+++ b/src/vue-plugins/http/module.js
@@ -101,11 +101,7 @@ export default {
         // Logs originating on the server possess an ID field; others do not.
           const newLog = makeLog.toServer(rootState.farm.logs[index]);
           return farm().log.send(newLog, localStorage.getItem('token')) // eslint-disable-line no-use-before-define, max-len
-            .then(res => handleSyncResponse(res, index))
-            .catch((err) => {
-              // If the API call returns an error, throw it up to the next level
-              throw new Error(err);
-            });
+            .then(res => handleSyncResponse(res, index));
         }),
       )
         .then((promises) => {
@@ -115,8 +111,7 @@ export default {
             if (promise.status === 'rejected') {
               // If the API call returns an error, add the index and http to sendErrors
               errorIndices.push(indices[arrayIndex]);
-              const statusCode = parseInt(String(promise.reason).substr(-3), 10);
-              errorStatus.push(statusCode);
+              errorStatus.push(parseInt(promise.reason.message.substr(-3), 10));
             }
           });
           if (errorIndices.length > 0) {

--- a/src/vue-plugins/http/module.js
+++ b/src/vue-plugins/http/module.js
@@ -100,15 +100,23 @@ export default {
         const newLog = makeLog.toServer(rootState.farm.logs[index]);
         return farm().log.send(newLog, localStorage.getItem('token')) // eslint-disable-line no-use-before-define, max-len
           .then(res => handleSyncResponse(res, index))
-          // .catch(err => handleSyncError(err, index, rootState, payload.router, commit));
           .catch((err) => {
-            console.log('CAUGHT AN ERROR FROM THE SERVER: ', '\n', err)
+            console.log('CAUGHT AN ERROR FROM THE SERVER AT INDEX: ', `${index}`, '\n', err)
             throw new SyncError({
               indices: [index],
               http: err,
             });
+          })
+          // .catch(err => handleSyncError(err, index, rootState, payload.router, commit));
+      }))
+        .catch((err) => {
+          // Re-throw the error as a higher-level error.
+          console.log('HIGHER LEVEL ERROR INDICES: ', '\n', err.indices);
+          throw new SyncError({
+            indices: err.indices,
+            http: err.http,
           });
-      }));
+        });
     },
 
     // GET LOGS FROM SERVER (step 1 of sync)


### PR DESCRIPTION
OK, I'm now able to catch multiple sendLogs errors and display a message that includes the names of the logs where they occurred.

The downside is, I had to use a timeout to do it.  Here's the problem:  Promise.all rejects after a single error is thrown.  It does not wait for subsequent errors.  Subsequent errors ARE caught internally by the arrow function in indices.map, and the the data from those errors are saved to arrays.  But without a timeout, handleSyncError in http/index is triggered at the moment Promise.all rejects, which occurs when  the FIRST error is thrown.  A 1 second timeout seems to take care of the issue.

I know this isn't an ideal solution, and there is a better one we might try in the future.  There's a new Promise.allSettled method that can collect an array of errors, and only rejects after all nested promises either resolve or reject.  Sadly Promise.allSettled isn't yet implemented by most browsers.  

If you feel the timeout hack is adequate for the moment, feel free to pull.  Otherwise, I can take another crack at working this out more elegantly.