### PR TITLE
Increase geolocation timeout to 10 seconds.

### DIFF
--- a/src/field-modules/my-logs/components/EditLog.vue
+++ b/src/field-modules/my-logs/components/EditLog.vue
@@ -743,7 +743,7 @@ export default {
       }
       const options = {
         enableHighAccuracy: true,
-        timeout: 5000,
+        timeout: 10000,
       };
 
       this.isWorking = true;
@@ -901,7 +901,7 @@ export default {
         }
         const options = {
           enableHighAccuracy: true,
-          timeout: 5000,
+          timeout: 10000,
         };
 
         navigator.geolocation.getCurrentPosition(


### PR DESCRIPTION
> Also worth noting: in some first tests (not logged in), it seemed like 5 second timeout was too short, and I wasn't able to get the location. I think increasing the timeout to 10 seconds is probably more reasonable. There are a lot of variables involved in the background (eg: the time it takes to get satellite signals varies), so maybe better to err on the longer side. That said, adding the timeout was a great improvement - no longer spinning indefinitely! :-)

https://github.com/farmOS/farmOS-client/issues/160#issuecomment-558300320