### PR TITLE
Use farmOS-map enableDraw() method instead of `drawing: true` initialization option (fixes #257).

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6909,8 +6909,8 @@
       "dev": true
     },
     "farmOS-map": {
-      "version": "github:farmOS/farmOS-map#cd43ebb4c9fcf5677a83c736c1c5e48f115ceb91",
-      "from": "github:farmOS/farmOS-map#v0.6.0",
+      "version": "github:farmOS/farmOS-map#f3f46ce8deed91963e8834724eaca80bdf8e4da7",
+      "from": "github:farmOS/farmOS-map#f3f46ce",
       "requires": {
         "ol": "^6.1.0",
         "ol-geocoder": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "cordova-plugin-splashscreen": "^5.0.3",
     "cordova-plugin-whitelist": "^1.3.4",
     "core-js-pure": "^3.2.1",
-    "farmOS-map": "farmOS/farmOS-map#v0.6.0",
+    "farmOS-map": "farmOS/farmOS-map#f3f46ce",
     "farmos": "0.0.6",
     "moment": "^2.22.2",
     "vue": "^2.6.10",

--- a/src/components/Map.vue
+++ b/src/components/Map.vue
@@ -27,17 +27,16 @@ export default {
   props: {
     id: String,
     overrideStyles: Object,
+    drawing: Boolean,
     options: {
       type: Object,
       controls: [Boolean, Array, Function],
       interactions: [Boolean, Array, Function],
-      drawing: Boolean,
       units: String,
       default() {
         return {
           controls: true,
           interactions: true,
-          drawing: false,
           units: 'us',
         };
       },
@@ -63,14 +62,15 @@ export default {
     if (this.geojson.url) {
       this.layers.geojson = this.map.addLayer('geojson', this.geojson);
     }
-    if (!this.options.drawing && this.wkt.wkt && this.wkt.wkt !== 'GEOMETRYCOLLECTION EMPTY') {
+    if (!this.drawing && this.wkt.wkt && this.wkt.wkt !== 'GEOMETRYCOLLECTION EMPTY') {
       this.layers.wkt = this.map.addLayer('wkt', this.wkt);
       this.map.zoomToLayer(this.layers.wkt);
     }
     if (this.geojson.url && (!this.wkt.wkt || this.wkt.wkt === 'GEOMETRYCOLLECTION EMPTY')) {
       this.layers.geojson.getSource().once('change', () => { this.map.zoomToVectors(); });
     }
-    if (this.options.drawing) {
+    if (this.drawing) {
+      this.map.enableDraw();
       if (this.wkt.wkt && this.wkt.wkt !== 'GEOMETRYCOLLECTION EMPTY') {
         this.map.edit.setWKT(this.wkt.wkt);
         this.map.zoomToLayer(this.map.edit.layer);
@@ -105,7 +105,7 @@ export default {
   },
   watch: {
     wkt(newWKT) {
-      if (!this.options.drawing) {
+      if (!this.drawing) {
         if (this.layers.wkt) {
           this.map.map.removeLayer(this.layers.wkt);
           this.layers.wkt = null;

--- a/src/components/Map.vue
+++ b/src/components/Map.vue
@@ -74,7 +74,6 @@ export default {
       if (this.wkt.wkt && this.wkt.wkt !== 'GEOMETRYCOLLECTION EMPTY') {
         this.map.edit.setWKT(this.wkt.wkt);
         this.map.zoomToLayer(this.map.edit.layer);
-        this.map.edit.layer.setZIndex(1);
       }
       this.map.edit.wktOn('drawend', (wkt) => {
         this.$emit('update-wkt', wkt);

--- a/src/components/Map.vue
+++ b/src/components/Map.vue
@@ -1,5 +1,5 @@
 <template>
-  <div 
+  <div
     :id="id"
     :style="[defaultStyles, overrideStyles]">
   </div>
@@ -66,7 +66,7 @@ export default {
     if (!this.options.drawing && this.wkt.wkt && this.wkt.wkt !== 'GEOMETRYCOLLECTION EMPTY') {
       this.layers.wkt = this.map.addLayer('wkt', this.wkt);
       this.map.zoomToLayer(this.layers.wkt);
-    } 
+    }
     if (this.geojson.url && (!this.wkt.wkt || this.wkt.wkt === 'GEOMETRYCOLLECTION EMPTY')) {
       this.layers.geojson.getSource().once('change', () => { this.map.zoomToVectors(); });
     }

--- a/src/field-modules/my-logs/components/EditLog.vue
+++ b/src/field-modules/my-logs/components/EditLog.vue
@@ -481,6 +481,7 @@
       <Map
         id="map"
         :overrideStyles="{ height: '90vw' }"
+        :drawing="false"
         :options="{
           controls: (defaults) => defaults.filter(def => def.constructor.name === 'Attribution'),
           interactions: false,

--- a/src/field-modules/my-logs/components/EditMap.vue
+++ b/src/field-modules/my-logs/components/EditMap.vue
@@ -29,7 +29,7 @@ export default {
   props: [ 'logs', 'id', 'systemOfMeasurement'],
   computed: {
     areaGeoJSON() {
-      return (process.env.NODE_ENV === 'development') 
+      return (process.env.NODE_ENV === 'development')
         ? 'http://localhost:8080/farm/areas/geojson/all'
         : `${localStorage.getItem('host')}/farm/areas/geojson/all`
     },

--- a/src/field-modules/my-logs/components/EditMap.vue
+++ b/src/field-modules/my-logs/components/EditMap.vue
@@ -3,9 +3,9 @@
     id="map"
     :overrideStyles="{ height: 'calc(100vh - 3rem)' }"
     @update-wkt="updateMovement"
+    :drawing="true"
     :options="{
       controls: (defs) => defs.filter(def => def.constructor.name !== 'FullScreen'),
-      drawing: true,
       units: systemOfMeasurement,
     }"
     :wkt="{


### PR DESCRIPTION
This updates the Map component code to use the new `enableDraw()` method for initializing drawing controls on a map, instead of passing `drawing: true` into the map initialization options. This allows the drawing controls to be added after other layers, so that the drawing layer can be on top.

See #257 for context. See also https://github.com/farmOS/farmOS-map/issues/50 in the farmOS-map repo for the change that was made upstream.