### PR TITLE
Update farmOS-map.js to v0.8.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6806,12 +6806,12 @@
       "dev": true
     },
     "farmOS-map": {
-      "version": "github:farmOS/farmOS-map#22c2ca2d2f2be34e5f5ab5882cde47ddc1742c82",
-      "from": "github:farmOS/farmOS-map#22c2ca2",
+      "version": "github:farmOS/farmOS-map#496eb80d33eaf2e5c3a263e2cf5f4b9e8d9dea54",
+      "from": "github:farmOS/farmOS-map#v0.8.0",
       "requires": {
         "ol": "^6.1.0",
         "ol-geocoder": "^4.0.0",
-        "ol-layerswitcher": "^3.3.0",
+        "ol-layerswitcher": "^3.5.0",
         "ol-popup": "^4.0.0"
       }
     },
@@ -10723,9 +10723,9 @@
       "integrity": "sha512-CPD62EgimRKbsXlQjJRx5m2z+ge0xc1mNzN61rn2J7icWuwuRZ48XH0F2aAA7uCCrtAf8ftYtz+xyJzRJS+syg=="
     },
     "ol-layerswitcher": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/ol-layerswitcher/-/ol-layerswitcher-3.4.0.tgz",
-      "integrity": "sha512-WhCf+UKyJuOIp9DehjhInATaiVK4ic89ZqxMlZ9vfEW1BsQ7Y7hDxoAlqgXtW9FQz2Ch558XIVMBRWfsB7CJ2w=="
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/ol-layerswitcher/-/ol-layerswitcher-3.5.0.tgz",
+      "integrity": "sha512-V5mVvw0s3XPHAi8HB9fQxreEwcwjUSsY+C5Ye6MtjXCi6peFbBg2HksxONQT+bdGwXQkXlmGdk8Dx315s+ob1g=="
     },
     "ol-popup": {
       "version": "4.0.0",
@@ -12815,9 +12815,9 @@
       "dev": true
     },
     "protocol-buffers-schema": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/protocol-buffers-schema/-/protocol-buffers-schema-3.3.2.tgz",
-      "integrity": "sha512-Xdayp8sB/mU+sUV4G7ws8xtYMGdQnxbeIfLjyO9TZZRJdztBGhlmbI5x1qcY4TG5hBkIKGnc28i7nXxaugu88w=="
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/protocol-buffers-schema/-/protocol-buffers-schema-3.4.0.tgz",
+      "integrity": "sha512-G/2kcamPF2S49W5yaMGdIpkG6+5wZF0fzBteLKgEHjbNzqjZQ85aAs1iJGto31EJaSTkNvHs5IXuHSaTLWBAiA=="
     },
     "proxy-addr": {
       "version": "2.0.5",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "cordova-plugin-splashscreen": "^5.0.3",
     "cordova-plugin-whitelist": "^1.3.4",
     "core-js-pure": "^3.4.7",
-    "farmOS-map": "github:farmOS/farmOS-map#v0.7.0",
+    "farmOS-map": "github:farmOS/farmOS-map#v0.8.0",
     "farmos": "0.0.7",
     "moment": "^2.24.0",
     "vue": "^2.6.10",

--- a/src/components/Map.vue
+++ b/src/components/Map.vue
@@ -73,9 +73,11 @@ export default {
       if (this.wkt.wkt && this.wkt.wkt !== 'GEOMETRYCOLLECTION EMPTY') {
         this.layers.wkt = this.map.addLayer('wkt', this.wkt);
         this.map.addBehavior('edit', { layer: this.layers.wkt });
+        this.map.addBehavior('measure', { layer: this.layers.wkt });
         this.map.zoomToLayer(this.layers.wkt);
       } else {
         this.map.addBehavior('edit');
+        this.map.addBehavior('measure', { layer: this.map.edit.layer });
       }
       this.map.edit.wktOn('drawend', (wkt) => {
         this.$emit('update-wkt', wkt);

--- a/src/components/Map.vue
+++ b/src/components/Map.vue
@@ -72,10 +72,10 @@ export default {
     if (this.drawing) {
       if (this.wkt.wkt && this.wkt.wkt !== 'GEOMETRYCOLLECTION EMPTY') {
         this.layers.wkt = this.map.addLayer('wkt', this.wkt);
-        this.map.enableDraw({ layer: this.layers.wkt });
+        this.map.addBehavior('edit', { layer: this.layers.wkt });
         this.map.zoomToLayer(this.layers.wkt);
       } else {
-        this.map.enableDraw();
+        this.map.addBehavior('edit');
       }
       this.map.edit.wktOn('drawend', (wkt) => {
         this.$emit('update-wkt', wkt);


### PR DESCRIPTION
There was a breaking change in farmOS-map.js between version v0.7.0 and v0.8.0. This PR updates the library version and the relevant code.