### PR TITLE
Display prev location

### DIFF
--- a/src/components/Map.vue
+++ b/src/components/Map.vue
@@ -44,7 +44,7 @@ export default {
     wkt: {
       type: Array,
       validator: wktArray => wktArray.every(e => typeof e.title === 'string'
-          && (typeof e.wkt === 'string' || e.wkt === null)
+          && (typeof e.wkt === 'string' || !e.wkt)
           && typeof e.color === 'string'
           && (!e.visible || typeof e.visible === 'boolean')
           && typeof e.weight === 'number'
@@ -61,7 +61,6 @@ export default {
     mapboxAPIKey: state => state.shell.mapboxAPIKey,
   }),
   mounted() {
-    // Render asset geometry
     this.map = window.farmOS.map.create(this.id, this.options);
     if (this.geojson.url) {
       this.layers.geojson = this.map.addLayer('geojson', this.geojson);

--- a/src/components/Map.vue
+++ b/src/components/Map.vue
@@ -43,19 +43,10 @@ export default {
     },
     wkt: {
       type: Array,
-      validator: wktArray => wktArray.every((e) => {
-        if (
-          typeof e.title === 'string'
-          && (typeof e.wkt === 'string'
-          || e.wkt === null)
+      validator: wktArray => wktArray.every(e => typeof e.title === 'string'
+          && (typeof e.wkt === 'string' || e.wkt === null)
           && typeof e.color === 'string'
-          && (!e.visible
-          || typeof e.visible === 'boolean')
-        ) {
-          return true;
-        }
-        return false;
-      }),
+          && (!e.visible || typeof e.visible === 'boolean')),
     },
     geojson: {
       title: String,
@@ -65,15 +56,10 @@ export default {
     },
   },
   computed: mapState({
-    /*
-    Add asset geometry to state
-    */
     mapboxAPIKey: state => state.shell.mapboxAPIKey,
   }),
   mounted() {
-    /*
-    Render asset geometry
-    */
+    // Render asset geometry
     this.map = window.farmOS.map.create(this.id, this.options);
     if (this.geojson.url) {
       this.layers.geojson = this.map.addLayer('geojson', this.geojson);
@@ -86,8 +72,7 @@ export default {
       */
       if (!this.drawing
         && wktElement.wkt
-        && wktElement.wkt !== 'GEOMETRYCOLLECTION EMPTY'
-        && wktElement.wkt !== null) {
+        && wktElement.wkt !== 'GEOMETRYCOLLECTION EMPTY') {
         this.layers[wktElement.title] = this.map.addLayer('wkt', wktElement);
         if (hasLayers && this.layers.movement) {
           this.map.zoomToLayer(this.layers.movement);
@@ -98,8 +83,7 @@ export default {
       }
       if (this.drawing) {
         if (wktElement.wkt
-          && wktElement.wkt !== 'GEOMETRYCOLLECTION EMPTY'
-          && wktElement.wkt !== null) {
+          && wktElement.wkt !== 'GEOMETRYCOLLECTION EMPTY') {
           if (wktElement.title === 'movement') {
             this.layers[wktElement.title] = this.map.addLayer('wkt', wktElement);
             this.map.zoomToLayer(this.layers.movement);
@@ -150,16 +134,11 @@ export default {
   watch: {
     wkt: {
       handler(newWKT) {
-        /*
-        TODO:
-        Figure out why this is triggering twice when a new area is added.
-        */
+        // TODO: Figure out why this is triggering twice when a new area is added.
         if (!this.drawing) {
           let hasLayers = false;
           newWKT.forEach((newElement) => {
-            /*
-            When multiple layers are present, the map zooms to the movement layer by default.
-            */
+            // When multiple layers are present, the map zooms to the movement layer by default.
             if (this.layers[newElement.title]) {
               this.map.map.removeLayer(this.layers[newElement.title]);
               this.layers[newElement.title] = null;

--- a/src/components/Map.vue
+++ b/src/components/Map.vue
@@ -108,6 +108,8 @@ export default {
           } else if (!hasLayers || !this.layers.movement) {
             this.layers[wktElement.title] = this.map.addLayer('wkt', wktElement);
             this.map.zoomToLayer(this.layers[wktElement.title]);
+          } else {
+            this.layers[wktElement.title] = this.map.addLayer('wkt', wktElement);
           }
           hasLayers = true;
         } else {

--- a/src/components/Map.vue
+++ b/src/components/Map.vue
@@ -101,24 +101,26 @@ export default {
       I need to add new layers, and name them wktElement.title
       */
       if (!this.drawing && wktElement.wkt && wktElement.wkt !== 'GEOMETRYCOLLECTION EMPTY') {
-        this.layers.wkt = this.map.addLayer('wkt', wktElement);
-        this.map.zoomToLayer(this.layers.wkt);
+        console.log('WKT ELEMENT TYPE:')
+        console.log(typeof wktElement.title);
+        this.layers[wktElement.title] = this.map.addLayer('wkt', wktElement);
+        this.map.zoomToLayer(this.layers[wktElement.title]);
       }
       if (this.geojson.url && (!wktElement.wkt || wktElement.wkt === 'GEOMETRYCOLLECTION EMPTY')) {
         this.layers.geojson.getSource().once('change', () => { this.map.zoomToVectors(); });
       }
       if (this.drawing) {
         if (wktElement.wkt && wktElement.wkt !== 'GEOMETRYCOLLECTION EMPTY') {
-          this.layers.wkt = this.map.addLayer('wkt', wktElement);
-          this.map.enableDraw({ layer: this.layers.wkt });
-          this.map.zoomToLayer(this.layers.wkt);
+          this.layers[wktElement.title] = this.map.addLayer('wkt', wktElement);
+          this.map.enableDraw({ layer: this.layers[wktElement.title] });
+          this.map.zoomToLayer(this.layers[wktElement.title]);
         } else {
           this.map.enableDraw();
         }
         /*
         Here, wkt is declared by the map itself, then passed on in the emit statement
         the update-wkt event triggers updateMovement in editMap.
-        I need to figure out what wkt consists of, and emit an object that denotes layers
+        I need to figure out what 'wkt' consists of
         */
         this.map.edit.wktOn('drawend', (wkt) => {
           this.$emit('update-wkt', wkt);
@@ -154,20 +156,18 @@ export default {
     wkt(newWKT) {
       // I will need to remove multiple layers when multiple have been added
       if (!this.drawing) {
-        if (this.layers.wkt) {
-          this.map.map.removeLayer(this.layers.wkt);
-          this.layers.wkt = null;
-        }
         this.wkt.forEach((newElement) => {
+          if (this.layers[newElement.title]) {
+            this.map.map.removeLayer(this.layers[newElement.title]);
+            this.layers[newElement.title] = null;
+          }
           if (newElement.wkt && newElement.wkt !== 'GEOMETRYCOLLECTION EMPTY') {
             console.log('NEWELEMENT');
             console.log(newElement);
             /*
-            This is a poor solution. It will add redundantly named layers from an array > 1
-            I can address this by naming layers newElement.title
             */
-            this.layers.wkt = this.map.addLayer('wkt', newElement);
-            this.map.zoomToLayer(this.layers.wkt);
+            this.layers[newElement.title] = this.map.addLayer('wkt', newElement);
+            this.map.zoomToLayer(this.layers[newElement.title]);
           } else {
             this.map.zoomToVectors();
           }

--- a/src/components/Map.vue
+++ b/src/components/Map.vue
@@ -103,13 +103,15 @@ export default {
           if (wktElement.title === 'movement') {
             console.log('ADDING WKT LAYER INSIDE DRAWING: '+wktElement.title);
             this.layers[wktElement.title] = this.map.addLayer('wkt', wktElement);
-            this.map.enableDraw({ layer: this.layers[wktElement.title] });
+            this.map.addBehavior('edit', { layer: this.layers[wktElement.title] });
+            this.map.addBehavior('measure', { layer: this.layers[wktElement.title] });
           } else {
             this.layers[wktElement.title] = this.map.addLayer('wkt', wktElement);
             this.map.zoomToLayer(this.layers[wktElement.title]);
           }
         } else {
-          this.map.enableDraw();
+          this.map.addBehavior('edit');
+          this.map.addBehavior('measure', { layer: this.map.edit.layer });
         }
         /*
         I may want to move these outside the for block

--- a/src/components/Map.vue
+++ b/src/components/Map.vue
@@ -100,7 +100,7 @@ export default {
         }
       }
     });
-    if (this.drawing) {
+    if (this.drawing && this.map.edit) {
       this.map.edit.wktOn('drawend', (wkt) => {
         this.$emit('update-wkt', wkt);
       });

--- a/src/components/Map.vue
+++ b/src/components/Map.vue
@@ -112,9 +112,6 @@ export default {
             this.layers[wktElement.title] = this.map.addLayer('wkt', wktElement);
           }
           hasLayers = true;
-        } else {
-          this.map.addBehavior('edit');
-          this.map.addBehavior('measure', { layer: this.map.edit.layer });
         }
       }
     });

--- a/src/components/Map.vue
+++ b/src/components/Map.vue
@@ -152,6 +152,10 @@ export default {
   watch: {
     wkt: {
       handler(newWKT) {
+        /*
+        TODO:
+        Figure out why this is triggering twice when a new area is added.
+        */
         if (!this.drawing) {
           let hasLayers = false;
           newWKT.forEach((newElement) => {

--- a/src/core/App.vue
+++ b/src/core/App.vue
@@ -97,7 +97,7 @@
 
 <script>
 import Vue from 'vue';
-import { mapState } from 'vuex';
+import { mapState, mapGetters } from 'vuex';
 import { version } from '../../package.json';
 import IconMenu from '@/components/icons/icon-menu';
 import IconArrowBack from '@/components/icons/icon-arrow-back';
@@ -125,8 +125,8 @@ const ModuleMenuItems = Vue.component('module-menu-items', {
             self.$store.commit('filterLogs', log => log.modules.includes(module.name));
             self.$store.dispatch('loadCachedLogs');
           },
-        }
-      }
+        },
+      },
     )));
   },
   props: {
@@ -161,36 +161,39 @@ export default {
     this.$store.dispatch('loadCachedAreas');
     this.$store.dispatch('loadCachedUnits');
     this.$store.dispatch('loadCachedCategories');
-    this.$store.dispatch('loadCachedEquipment');
   },
-  computed: mapState({
-    /**
-     * SHELL STATE
-     */
-    errors: state => state.shell.errors,
-    username: state => state.shell.user.name,
-    userId: state => state.shell.user.uid,
-    isLoggedIn: state => state.shell.user.isLoggedIn,
-    useGeolocation: state => state.shell.settings.useGeolocation,
-    systemOfMeasurement: state => state.shell.systemOfMeasurement,
-    logTypes: state => state.shell.logTypes,
-    farmName: state => state.shell.farmInfo.name,
-    // Provide an example url for the dev server environment
-    farmUrl: state => ((state.shell.farmInfo.url === '')
-      ? 'example.farmos.net'
-      : state.shell.farmInfo.url),
-    modules: state => state.shell.modules,
+  computed: {
+    ...mapState({
+      /**
+       * SHELL STATE
+       */
+      errors: state => state.shell.errors,
+      username: state => state.shell.user.name,
+      userId: state => state.shell.user.uid,
+      isLoggedIn: state => state.shell.user.isLoggedIn,
+      useGeolocation: state => state.shell.settings.useGeolocation,
+      systemOfMeasurement: state => state.shell.systemOfMeasurement,
+      logTypes: state => state.shell.logTypes,
+      farmName: state => state.shell.farmInfo.name,
+      // Provide an example url for the dev server environment
+      farmUrl: state => ((state.shell.farmInfo.url === '')
+        ? 'example.farmos.net'
+        : state.shell.farmInfo.url),
+      modules: state => state.shell.modules,
 
-    /**
-     * FARM STATE
-     */
-    logs: state => state.farm.logs,
-    areas: state => state.farm.areas,
-    assets: state => state.farm.assets,
-    units: state => state.farm.units,
-    categories: state => state.farm.categories,
-    equipment: state => state.farm.equipment,
-  }),
+      /**
+       * FARM STATE
+       */
+      logs: state => state.farm.logs,
+      areas: state => state.farm.areas,
+      assets: state => state.farm.assets,
+      units: state => state.farm.units,
+      categories: state => state.farm.categories,
+    }),
+    ...mapGetters([
+      'equipment',
+    ]),
+  },
   watch: {
     showDrawer(currentShowDrawer) {
       if (currentShowDrawer) {

--- a/src/core/store/farmModule.js
+++ b/src/core/store/farmModule.js
@@ -53,7 +53,11 @@ export default {
     areas: [],
     units: [],
     categories: [],
-    equipment: [],
+  },
+  getters: {
+    equipment(state) {
+      return state.assets.filter(a => a.type === 'equipment');
+    },
   },
   mutations: {
     addLogs: makeEntityAdder('logs', 'localID'),
@@ -61,7 +65,6 @@ export default {
     addAreas: makeEntityAdder('areas', 'tid'),
     addUnits: makeEntityAdder('units', 'tid'),
     addCategories: makeEntityAdder('categories', 'tid'),
-    addEquipment: makeEntityAdder('equipment', 'id'),
     // Takes a function as payload and applies it to each log object
     updateAllLogs(state, fn) {
       state.logs = state.logs.map(log => fn(log));
@@ -81,9 +84,6 @@ export default {
     },
     deleteAllCategories(state) {
       state.categories = [];
-    },
-    deleteAllEquipment(state) {
-      state.equipment = [];
     },
     filterLogs(state, predicate) {
       const filteredLogs = state.logs.filter(predicate);

--- a/src/core/store/http/module.js
+++ b/src/core/store/http/module.js
@@ -71,7 +71,7 @@ export default {
       return farm().asset.get().then((res) => {
         // If a successful response is received, delete and replace all assets
         commit('deleteAllAssets');
-        const assets = res.list.map(({ id, name, type }) => ({ id, name, type }));
+        const assets = res.list.map(({ id, name, type, geometry }) => ({ id, name, type, geometry }));
         commit('addAssets', assets);
       });
     },
@@ -94,7 +94,7 @@ export default {
     updateEquipment({ commit }) {
       return farm().asset.get().then((res) => {
         commit('deleteAllEquipment');
-        const assets = res.list.map(({ id, name, type }) => ({ id, name, type }));
+        const assets = res.list.map(({ id, name, type, geometry }) => ({ id, name, type, geometry }));
         const equipment = assets.filter(a => a.type === 'equipment');
         commit('addEquipment', equipment);
       });

--- a/src/core/store/http/module.js
+++ b/src/core/store/http/module.js
@@ -71,8 +71,7 @@ export default {
       return farm().asset.get().then((res) => {
         // If a successful response is received, delete and replace all assets
         commit('deleteAllAssets');
-        const assets = res.list.map(({ id, name, type, geometry }) => ({ id, name, type, geometry }));
-        commit('addAssets', assets);
+        commit('addAssets', res.list);
       });
     },
     updateUnits({ commit }) {

--- a/src/core/store/http/module.js
+++ b/src/core/store/http/module.js
@@ -90,14 +90,6 @@ export default {
         commit('addCategories', cats);
       });
     },
-    updateEquipment({ commit }) {
-      return farm().asset.get().then((res) => {
-        commit('deleteAllEquipment');
-        const assets = res.list.map(({ id, name, type, geometry }) => ({ id, name, type, geometry }));
-        const equipment = assets.filter(a => a.type === 'equipment');
-        commit('addEquipment', equipment);
-      });
-    },
 
     // SEND LOGS TO SERVER (step 2 of sync)
     sendLogs({ commit, rootState }, indices) {

--- a/src/core/store/idb/idb.config.js
+++ b/src/core/store/idb/idb.config.js
@@ -6,7 +6,7 @@ import categoryUpgrades from './upgrades/categories';
 import equipmentUpgrades from './upgrades/equipment';
 
 export default {
-  version: 3,
+  version: 4,
   name: 'farmos',
   stores: [
     {

--- a/src/core/store/idb/module.js
+++ b/src/core/store/idb/module.js
@@ -16,7 +16,6 @@ const [
   areaStore,
   unitStore,
   catStore,
-  equipStore,
 ] = config.stores;
 
 export default {
@@ -193,34 +192,6 @@ export default {
         .then(db => getRecords(db, catStore.name))
         .then((results) => {
           commit('addCategories', results);
-        })
-        .catch(console.error); // eslint-disable-line no-console
-    },
-
-    createCachedEquipment(_, newEquip) {
-      openDatabase()
-        .then(db => saveRecord(db, equipStore.name, newEquip))
-        .catch(console.error); // eslint-disable-line no-console
-    },
-
-    // TODO: Remove duplication with createCachedEquipment
-    updateCachedEquipment(context, equip) {
-      openDatabase()
-        .then(db => saveRecord(db, equipStore.name, equip))
-        .catch(console.error); // eslint-disable-line no-console
-    },
-
-    deleteAllCachedEquipment() {
-      openDatabase()
-        .then(db => clearStore(db, equipStore.name))
-        .catch(console.error); // eslint-disable-line no-console
-    },
-
-    loadCachedEquipment({ commit }) {
-      openDatabase()
-        .then(db => getRecords(db, equipStore.name))
-        .then((results) => {
-          commit('addEquipment', results);
         })
         .catch(console.error); // eslint-disable-line no-console
     },

--- a/src/core/store/idb/upgrades/equipment.js
+++ b/src/core/store/idb/upgrades/equipment.js
@@ -13,4 +13,22 @@ export default [
       });
     },
   },
+  {
+    /**
+     * Starting with this version, equipment will merely be a getter value,
+     * derived from assets, so we don't need to fetch or store it separately.
+     */
+    version: 4,
+    onUpgrade(event) {
+      return new Promise((resolve, reject) => {
+        const db = event.target.result;
+        try {
+          db.deleteObjectStore('equipment');
+          resolve();
+        } catch (error) {
+          reject(error);
+        }
+      });
+    },
+  },
 ];

--- a/src/field-modules/my-logs/components/EditLog.vue
+++ b/src/field-modules/my-logs/components/EditLog.vue
@@ -526,13 +526,7 @@
           controls: (defaults) => defaults.filter(def => def.constructor.name === 'Attribution'),
           interactions: false,
         }"
-        :wkt="[{
-          title: 'movement',
-          wkt: currentLog.movement
-            ? currentLog.movement.geometry
-            : undefined,
-          color: 'orange',
-        }]"
+        :wkt=mapLayers
         :geojson="{
           title: 'areas',
           url: areaGeoJSON,
@@ -981,6 +975,17 @@ export default {
     imageUrls() {
       return this.currentLog.images
         .filter(img => typeof img === 'string');
+    },
+    /*
+    Assemble layers for display
+    */
+    mapLayers() {
+      const movement = {
+        title: 'movement',
+        wkt: this.currentLog?.movement.data.geometry,
+        color: 'orange',
+      };
+      return [movement];
     },
   },
 

--- a/src/field-modules/my-logs/components/EditLog.vue
+++ b/src/field-modules/my-logs/components/EditLog.vue
@@ -514,6 +514,10 @@
     </div>
 
     <router-link :to="{ name: 'edit-map' }">
+      <!--
+      I need to build the wkt array in a method.
+      For now I just added [] around the single, hard-coded wkt.
+    -->
       <Map
         id="map"
         :overrideStyles="{ height: '90vw' }"
@@ -522,13 +526,13 @@
           controls: (defaults) => defaults.filter(def => def.constructor.name === 'Attribution'),
           interactions: false,
         }"
-        :wkt="{
+        :wkt="[{
           title: 'movement',
           wkt: currentLog.movement
             ? currentLog.movement.geometry
             : undefined,
           color: 'orange',
-        }"
+        }]"
         :geojson="{
           title: 'areas',
           url: areaGeoJSON,

--- a/src/field-modules/my-logs/components/EditLog.vue
+++ b/src/field-modules/my-logs/components/EditLog.vue
@@ -513,7 +513,7 @@
       </ul>
     </div>
 
-    <router-link :to="{ name: 'edit-map', params: { mapLayers: mapLayers }}">
+    <router-link :to="{ name: 'edit-map'}">
       <Map
         id="map"
         :overrideStyles="{ height: '90vw' }"
@@ -990,26 +990,16 @@ export default {
         color: 'orange',
         visible: true,
         weight: 0,
-        canEdit: !!this.logs[this.currentLogIndex].movement.data.geometry,
+        canEdit: !!this.currentLog.movement.data.geometry,
       };
-      const assembledPrevious = () => {
-        const fields = [];
-        if (this.currentLog.geofield.data.length > 0) {
-          fields.push(this.currentLog.geofield.data[0].geom);
-        }
-        this.logAreas.forEach((logArea) => {
-          const areaGeom = (this.areas.find(area => area.tid === logArea.id).geofield[0])
-            ? this.areas.find(area => area.tid === logArea.id).geofield[0].geom
-            : null;
-          if (areaGeom) { fields.push(areaGeom); }
-        });
-        return fields.length > 0
-          ? mergeGeometries(fields)
-          : null;
-      };
+      const previousGeoms = this.logAreas
+        .map(logArea => this.areas.find(area => area.tid === logArea.id).geofield?.[0].geom)
+        .concat(this.currentLog.geofield.data?.[0].geom)
+        .filter(a => !!a);
+      const previousWKT = mergeGeometries(previousGeoms);
       const previous = {
         title: 'previous',
-        wkt: assembledPrevious(),
+        wkt: previousWKT,
         color: 'green',
         visible: true,
         weight: 1,

--- a/src/field-modules/my-logs/components/EditLog.vue
+++ b/src/field-modules/my-logs/components/EditLog.vue
@@ -996,10 +996,9 @@ export default {
         weight: 0,
         canEdit: !!this.currentLog.movement?.geometry,
       };
-      const previousGeoms = this.currentLog.area
-        ?.map(logArea => this.areas.find(area => area.tid === logArea.id).geofield?.[0].geom)
-        ?.concat(this.currentLog.geofield?.[0].geom)
-        ?.filter(a => !!a);
+      const previousGeoms = this.currentLog.asset
+        ?.map(logAsset => this.assets
+        ?.find(asset => asset.id === logAsset.id)?.geometry);
       const previousWKT = previousGeoms ? mergeGeometries(previousGeoms) : undefined;
       const previous = {
         title: 'previous',

--- a/src/field-modules/my-logs/components/EditLog.vue
+++ b/src/field-modules/my-logs/components/EditLog.vue
@@ -989,6 +989,8 @@ export default {
         wkt: this.currentLog?.movement.data.geometry,
         color: 'orange',
         visible: true,
+        weight: 0,
+        canEdit: !!this.logs[this.currentLogIndex].movement.data.geometry,
       };
       const assembledPrevious = () => {
         const fields = [];
@@ -1008,8 +1010,10 @@ export default {
       const previous = {
         title: 'previous',
         wkt: assembledPrevious(),
-        color: 'blue',
+        color: 'green',
         visible: true,
+        weight: 1,
+        canEdit: false,
       };
       return [movement, previous];
     },

--- a/src/field-modules/my-logs/components/EditLog.vue
+++ b/src/field-modules/my-logs/components/EditLog.vue
@@ -514,10 +514,6 @@
     </div>
 
     <router-link :to="{ name: 'edit-map' }">
-      <!--
-      I need to build the wkt array in a method.
-      For now I just added [] around the single, hard-coded wkt.
-    -->
       <Map
         id="map"
         :overrideStyles="{ height: '90vw' }"
@@ -984,8 +980,15 @@ export default {
         title: 'movement',
         wkt: this.currentLog?.movement.data.geometry,
         color: 'orange',
+        visible: true,
       };
-      return [movement];
+      const previous = {
+        title: 'previous',
+        wkt: this.currentLog.geofield.data?.[0].geom,
+        color: 'blue',
+        visible: true,
+      };
+      return [movement, previous];
     },
   },
 

--- a/src/field-modules/my-logs/components/EditLog.vue
+++ b/src/field-modules/my-logs/components/EditLog.vue
@@ -1031,7 +1031,7 @@ export default {
     /*
     Watch for newly added or deleted areas and update the geofield accordingly.
     This will update map layers in turn.
-    TODO (POSSIBLY)
+    TODO
     Here I am following the behavior of the farmOS server UI.
     On the server, only the first area that is added is displayed on the map.
     In the future it might be useful to mergeGeometries to display all areas.

--- a/src/field-modules/my-logs/components/EditLog.vue
+++ b/src/field-modules/my-logs/components/EditLog.vue
@@ -513,7 +513,7 @@
       </ul>
     </div>
 
-    <router-link :to="{ name: 'edit-map'}">
+    <router-link :to="{ name: 'edit-map' }">
       <Map
         id="map"
         :overrideStyles="{ height: '90vw' }"
@@ -998,7 +998,7 @@ export default {
       };
       const previousGeoms = this.currentLog.asset
         ?.map(logAsset => this.assets
-        ?.find(asset => asset.id === logAsset.id)?.geometry);
+          ?.find(asset => asset.id === logAsset.id)?.geometry);
       const previousWKT = previousGeoms ? mergeGeometries(previousGeoms) : undefined;
       const previous = {
         title: 'previous',

--- a/src/field-modules/my-logs/components/EditMap.vue
+++ b/src/field-modules/my-logs/components/EditMap.vue
@@ -54,7 +54,7 @@ export default {
       };
       const previousGeoms = this.currentLog.asset
         ?.map(logAsset => this.assets
-        ?.find(asset => asset.id === logAsset.id)?.geometry);
+          ?.find(asset => asset.id === logAsset.id)?.geometry);
       const previousWKT = mergeGeometries(previousGeoms);
       const previous = {
         title: 'previous',

--- a/src/field-modules/my-logs/components/EditMap.vue
+++ b/src/field-modules/my-logs/components/EditMap.vue
@@ -1,4 +1,8 @@
 <template>
+  <!--
+  I need to build the wkt array in a method.
+  For now I just added [] around the single, hard-coded wkt.
+-->
   <Map
     id="map"
     :overrideStyles="{ height: 'calc(100vh - 3rem)' }"
@@ -8,13 +12,13 @@
       controls: (defs) => defs.filter(def => def.constructor.name !== 'FullScreen'),
       units: systemOfMeasurement,
     }"
-    :wkt="{
+    :wkt="[{
       title: 'movement',
       wkt: currentLog.movement
         ? currentLog.movement.geometry
         : undefined,
       color: 'orange',
-    }"
+    }]"
     :geojson="{
       title: 'areas',
       url: areaGeoJSON,

--- a/src/field-modules/my-logs/components/EditMap.vue
+++ b/src/field-modules/my-logs/components/EditMap.vue
@@ -37,11 +37,6 @@ export default {
     currentLog() {
       return this.logs.find(log => log.localID === +this.id) || this.logs[0];
     },
-    logAreas() {
-      return this.currentLog.area.data
-        ? this.currentLog.area.data
-        : null;
-    },
     /*
     Assemble layers for display.
     The 'previous' layer is assembled from the geofield plus
@@ -51,16 +46,16 @@ export default {
     mapLayers() {
       const movement = {
         title: 'movement',
-        wkt: this.currentLog?.movement.data.geometry,
+        wkt: this.currentLog.movement?.geometry,
         color: 'orange',
         visible: true,
         weight: 0,
-        canEdit: !!this.currentLog.movement.data.geometry,
+        canEdit: !!this.currentLog.movement?.geometry,
       };
-      const previousGeoms = this.logAreas
-        .map(logArea => this.areas.find(area => area.tid === logArea.id).geofield?.[0].geom)
-        .concat(this.currentLog.geofield.data?.[0].geom)
-        .filter(a => !!a);
+      const previousGeoms = this.currentLog.area
+        ?.map(logArea => this.areas.find(area => area.tid === logArea.id).geofield?.[0].geom)
+        ?.concat(this.currentLog.geofield?.[0].geom)
+        ?.filter(a => !!a);
       const previousWKT = mergeGeometries(previousGeoms);
       const previous = {
         title: 'previous',

--- a/src/field-modules/my-logs/components/EditMap.vue
+++ b/src/field-modules/my-logs/components/EditMap.vue
@@ -24,7 +24,7 @@ export default {
   name: 'EditMap',
   components: { Map },
   props: ['logs',
-    'areas',
+    'assets',
     'id',
     'systemOfMeasurement'],
 
@@ -52,10 +52,9 @@ export default {
         weight: 0,
         canEdit: !!this.currentLog.movement?.geometry,
       };
-      const previousGeoms = this.currentLog.area
-        ?.map(logArea => this.areas.find(area => area.tid === logArea.id).geofield?.[0].geom)
-        ?.concat(this.currentLog.geofield?.[0].geom)
-        ?.filter(a => !!a);
+      const previousGeoms = this.currentLog.asset
+        ?.map(logAsset => this.assets
+        ?.find(asset => asset.id === logAsset.id)?.geometry);
       const previousWKT = mergeGeometries(previousGeoms);
       const previous = {
         title: 'previous',

--- a/src/field-modules/my-logs/components/EditMap.vue
+++ b/src/field-modules/my-logs/components/EditMap.vue
@@ -1,8 +1,4 @@
 <template>
-  <!--
-  I need to build the wkt array in a method.
-  For now I just added [] around the single, hard-coded wkt.
--->
   <Map
     id="map"
     :overrideStyles="{ height: 'calc(100vh - 3rem)' }"
@@ -12,13 +8,7 @@
       controls: (defs) => defs.filter(def => def.constructor.name !== 'FullScreen'),
       units: systemOfMeasurement,
     }"
-    :wkt="[{
-      title: 'movement',
-      wkt: currentLog.movement
-        ? currentLog.movement.geometry
-        : undefined,
-      color: 'orange',
-    }]"
+    :wkt=mapLayers
     :geojson="{
       title: 'areas',
       url: areaGeoJSON,
@@ -41,6 +31,24 @@ export default {
     },
     currentLog() {
       return this.logs.find(log => log.localID === +this.id) || this.logs[0];
+    },
+    /*
+    Assemble layers for display
+    */
+    mapLayers() {
+      const movement = {
+        title: 'movement',
+        wkt: this.currentLog?.movement.data.geometry,
+        color: 'orange',
+        visible: true,
+      };
+      const previous = {
+        title: 'previous',
+        wkt: this.currentLog.geofield.data.geofield.data?.[0].geom,
+        color: 'blue',
+        visible: true,
+      };
+      return [movement, previous];
     },
   },
   methods: {

--- a/src/field-modules/my-logs/components/EditMap.vue
+++ b/src/field-modules/my-logs/components/EditMap.vue
@@ -22,7 +22,11 @@ import Map from '@/components/Map';
 export default {
   name: 'EditMap',
   components: { Map },
-  props: ['logs', 'id', 'systemOfMeasurement'],
+  props: ['logs',
+    'id',
+    'systemOfMeasurement',
+    'mapLayers'],
+
   computed: {
     areaGeoJSON() {
       return (process.env.NODE_ENV === 'development')
@@ -32,25 +36,8 @@ export default {
     currentLog() {
       return this.logs.find(log => log.localID === +this.id) || this.logs[0];
     },
-    /*
-    Assemble layers for display
-    */
-    mapLayers() {
-      const movement = {
-        title: 'movement',
-        wkt: this.currentLog?.movement.data.geometry,
-        color: 'orange',
-        visible: true,
-      };
-      const previous = {
-        title: 'previous',
-        wkt: this.currentLog.geofield.data.geofield.data?.[0].geom,
-        color: 'blue',
-        visible: true,
-      };
-      return [movement, previous];
-    },
   },
+
   methods: {
     updateMovement(wkt) {
       const props = {

--- a/src/field-modules/my-logs/components/Logs.vue
+++ b/src/field-modules/my-logs/components/Logs.vue
@@ -144,7 +144,6 @@ export default {
       this.$store.dispatch('updateAreas');
       this.$store.dispatch('updateUnits');
       this.$store.dispatch('updateCategories');
-      this.$store.dispatch('updateEquipment');
     },
 
     /**


### PR DESCRIPTION
This appears to be working!  The behavior is as-outlined in the proposal: 
- Movement and Previous layers are created in editLog.vue and passed to map.vue and editMap.vue
- The Previous layer is assembled from the geofield plus all area geometries associated with the log.
- The 'movement' layer is the geometry in the log's movement field
- The movement layer is displayed in yellow, and previous is displayed in blue

One small issue: the Previous color (blue) is also our drawing color.  I think that needs to be changed in farmOS-map.  If that's too much of a pain, I could change the Previous color to something else.
