### PR TITLE
Add WKViewOnly flag to config.ios.xml.

### DIFF
--- a/config.ios.xml
+++ b/config.ios.xml
@@ -45,6 +45,13 @@
     <engine name="android" spec="^7.1.1" />
     <engine name="ios" spec="^4.5.5" />
     <plugin name="cordova-plugin-splashscreen" spec="^5.0.2" />
+    <platform name="ios">
+        <preference name="WKWebViewOnly" value="true" />
+        <feature name="CDVWKWebViewEngine">
+            <param name="ios-package" value="CDVWKWebViewEngine" />
+        </feature>
+        <preference name="CordovaWebViewEngine" value="CDVWKWebViewEngine" />
+    </platform>
     <platform name="android">
     	<icon qualifier="ldpi" src="res/icons/android/drawable-ldpi-icon.png" />
     	<icon qualifier="mdpi" src="res/icons/android/drawable-mdpi-icon.png" />

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "cordova-plugin-network-information": "^2.0.2",
     "cordova-plugin-splashscreen": "^5.0.3",
     "cordova-plugin-whitelist": "^1.3.4",
+    "cordova-plugin-wkwebview-engine": "^1.2.1",
     "core-js-pure": "^3.4.7",
     "farmOS-map": "github:farmOS/farmOS-map#d50daf5014039cda75345bd0ce34adc4475e1f5c",
     "farmos": "^0.1.2",
@@ -120,7 +121,8 @@
       },
       "cordova-plugin-file": {},
       "cordova-plugin-geolocation": {},
-      "cordova-plugin-splashscreen": {}
+      "cordova-plugin-splashscreen": {},
+      "cordova-plugin-wkwebview-engine": {}
     },
     "platforms": [
       "ios",


### PR DESCRIPTION
This addresses the eventuality that login _fails_ when iOS is rolled back to v0.4.15, and assumes the following was the cause in https://github.com/farmOS/farmOS-client/issues/324#issuecomment-605270324:

> 1. Apple has deprecated UIWebView sooner than they announced (see #320), and this has broken essential browser API's such as XMLHttpRequest and Geolocation.

The proposed solution,

> we need to push out a release that successfully migrates us to WKWebView to see if that alone fixes it

is implemented here. PR #335 is its counterpart implementation in case the login _succeeds_.

If we get confirmation that login fails in iOS at v0.4.15, we need to merge this in and deploy it ASAP, as v0.4.17, so we can resolve #320. If login succeeds, we can keep this PR open and use the branch as a basis for the the eventual migration to WKWebView, which will still need to happen, once we have also implemented OAuth (#311). PR #335 will only be a stopgap measure, in the case we need to develop OAuth.