### PR TITLE
Remove cordova-plugin-wkwebview-engine.

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
     "cordova-plugin-network-information": "^2.0.2",
     "cordova-plugin-splashscreen": "^5.0.3",
     "cordova-plugin-whitelist": "^1.3.4",
-    "cordova-plugin-wkwebview-engine": "^1.2.1",
     "core-js-pure": "^3.4.7",
     "farmOS-map": "github:farmOS/farmOS-map#v1.0.0",
     "farmos": "0.0.9",
@@ -120,8 +119,7 @@
       },
       "cordova-plugin-file": {},
       "cordova-plugin-geolocation": {},
-      "cordova-plugin-splashscreen": {},
-      "cordova-plugin-wkwebview-engine": {}
+      "cordova-plugin-splashscreen": {}
     },
     "platforms": [
       "ios",


### PR DESCRIPTION
This addresses the eventuality that login _succeeds_ when iOS is rolled back to v0.4.15, and assumes the following was the cause in https://github.com/farmOS/farmOS-client/issues/324#issuecomment-605270324:

> 2. Contrary to what I thought, commit c549d7b _did_ succeed in activating the WKWebView engine, (even though it still triggered Apple's deprecation warning; see https://github.com/apache/cordova-plugin-wkwebview-engine/issues/125#issuecomment-560437509); also, WKWebView _is_ treating XHR requests from the `file://` protocol as CORS requests, as per [this notice](https://github.com/apache/cordova-plugin-wkwebview-engine#cordova-wkwebview-engine); therefore, Apple's prohibition against cross-site cookies is breaking our authentication procedure the same way it is for the PWA (see #328).

The proposed solution,

> - Prepare an 0.4.17 release, which just reverts the WKWebView plugin, but keeps the fixes for quantities and the white screen of death, and get that pushed out before April 1. Hopefully that will buy us time for the next steps, since Apple is only disallowing _new submissions_ starting in April, and hopefully won't deprecate UIWebView in older submissions.
> - Keep a branch that retains the WKWebView commit, and add the necessary configuration to make sure it no longer triggers the deprecation warning from Apple (see https://github.com/farmOS/farmOS-client/issues/320#issuecomment-604096260).
> -  Start implementing OAuth (#311) ASAP, so once we are forced to release with WKWebView, we have an authentication procedure in place that will work with it.


is implemented here. PR #334 is counterpart implementation in case the login _fails_.

If we get confirmation that login succeeds in iOS at v0.4.15, we need to merge this in and deploy it ASAP, as v0.4.17, so we can submit a UIWebView build before the April deadline. If login fails, this PR can probably be closed and the branch discarded, because at that point we should be committing to using WKWebView and will have no need to revert. This PR is only a stopgap measure in the case that we need more time to develop OAuth.