### PR TITLE
Delete CNAME

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,0 @@
-farmOS.app


### PR DESCRIPTION
I think we can delete this file now, because we are no longer using GitHub Pages to host https://farmOS.app.