### PR TITLE
Replace global object w/ mountFieldModule method.

### DIFF
--- a/API.md
+++ b/API.md
@@ -1,0 +1,38 @@
+# Field Kit / Field Modules API
+farmOS Field Kit is a not just an application but a framework for building concise user interfaces that capture specialized subsets of farm-related data. We use a [microfrontend](https://www.martinfowler.com/articles/micro-frontends.html) architecture to deliver these UI's at runtime to the Field Kit client from any farmOS server. These are called Field Modules. They make up the "kit" that farmers take to the "field".
+
+# Getting started
+
+[Instructions will go here once we have a template repo.]
+
+# Basic requirements
+The Field Module API is fairly flexible, granting a fair amount of latitude to the developer to make their own choices. There are only a few basic requirements in order to load a Field Module into Field Kit. The primary interface is the main module object, which is mounted in the module's main entry point, `index.js`:
+
+```js
+// src/FieldModule/MyModule/js/index.js
+import ModuleWidget from './components/ModuleWidget';
+import Module from './components/Module';
+import ModuleMenuBar from './components/ModuleMenuBar';
+
+const mod = {
+  name: 'my-mod',
+  label: 'My Module',
+  widget: ModuleWidget,
+  routes: [
+    {
+      name: 'module',
+      path: '/module',
+      components: {
+        default: Module,
+        menubar: ModuleMenuBar,
+      },
+    },
+  ],
+};
+
+window.farmOS.mountFieldModule(mod);
+```
+
+The `name` must be a unique identifier which is used internallay by Field Kit to distinguish your module from all others. The `label` will be displayed in the main menu with a link to your module's main route. The `widget` is a Vue component which is displayed on the home screen. It will automatically be nested in a card with your `label` as a heading, but otherwsie it can be customized to display info about your module and provide links to various routes within your module. Finally, `routes` is an array of `RouteConfig` objects, as specified in the [Vue router API](https://router.vuejs.org/api/#routes).
+
+Once your module object is complete, you can mount it by calling the globale `farmOS.mountFieldModule()` method.

--- a/src/core/app.js
+++ b/src/core/app.js
@@ -8,7 +8,7 @@ import './bootstrap-simplex.min.css';
 import './vars.css';
 import './main.css';
 import utils from '../utils';
-import { createModuleLoader, createFieldModule, setRootRoute } from '../utils/fieldModules';
+import { createFieldModule, loadFieldModule, setRootRoute } from '../utils/fieldModules';
 import components from '../components';
 
 Vue.config.productionTip = false;
@@ -19,17 +19,14 @@ if (window.farmOS === undefined) {
 }
 window.farmOS.utils = utils;
 
-// Provide a global namespace to which modules can attach their config.
-if (window.farmOS.modules === undefined) {
-  window.farmOS.modules = {};
-}
-
 // Register the shared component library globally so they can be accessed from
 // any other component on the root Vue instance.
 components.forEach((c) => { Vue.component(c.name, c); });
 
+
+// Provide a global function for mounting Field Modules with all its dependencies.
 const deps = { ...store, state: store.state, router };
-const loadFieldModule = createModuleLoader(deps);
+window.farmOS.mountFieldModule = mod => createFieldModule(mod, deps);
 
 export default (el, buildtimeMods) => {
   // Load build-time modules

--- a/src/core/store/shellModule.js
+++ b/src/core/store/shellModule.js
@@ -1,7 +1,7 @@
 // A Vuex module for holding state for the application shell.
 import defaultLogTypes from './defaultLogTypes';
 import farm from './farmClient';
-import { createModuleLoader, setRootRoute } from '../../utils/fieldModules';
+import { createFieldModule, loadFieldModule, setRootRoute } from '../../utils/fieldModules';
 
 export default {
   state: {
@@ -93,7 +93,9 @@ export default {
         dispatch,
         router,
       };
-      const loadFieldModule = createModuleLoader(deps);
+
+      // Overwrite the mounting function so it has the most recent state.
+      window.farmOS.mountFieldModule = mod => createFieldModule(mod, deps);
 
       return farm().info()
         .then((res) => {

--- a/src/utils/fieldModules.js
+++ b/src/utils/fieldModules.js
@@ -95,7 +95,7 @@ export const createFieldModule = (modConfig, deps) => {
   router.addRoutes(createRoutes(name, routes, deps));
 };
 
-export const createModuleLoader = deps => (module) => {
+export const loadFieldModule = (module) => {
   const script = document.createElement('script');
   script.src = `${localStorage.getItem('host')}/${module.js}`;
   script.id = `field-module-${module.name}`;
@@ -103,10 +103,12 @@ export const createModuleLoader = deps => (module) => {
   script.async = true;
   script.crossOrigin = 'anonymous';
   script.onload = () => {
-    const config = window.farmOS.modules[module.name];
-    createFieldModule(config, deps);
+    // eslint-disable-next-line no-console
+    console.log(`${module.label} loaded successfully!`);
   };
-  // eslint-disable-next-line no-console
-  script.onerror = () => console.error(`Error installing ${module.label} module`);
+  script.onerror = () => {
+    // eslint-disable-next-line no-console
+    console.error(`Error installing ${module.label}.`);
+  };
   document.body.appendChild(script);
 };


### PR DESCRIPTION
A great thing about writing documentation is it makes you look at your API from the inside out, and you see things in a new light.

I realized writing the documentation for 0.6.0 that it was kinda funky the way we were requiring the Field Module be mounted with an assignment to the global namespace:

```js
window.farmOS.modules[modConfig.name] = modConfig;
```

It reveals a few more implementation details than I'd like, plus we don't really have any other reason to expose the module config globally like that (it get's pulled into Vuex separately), and it's just plain ugly.

So I know this is a breaking change, but I just wanted to provide a function instead; so now it's,

```js
window.farmOS.mountFieldModule(module);
```

which seems much cleaner. It will allow for more a more flexible implementation, because that `mountFieldModule` method can be whatever we want, essentially. I also stopped referring to it as the `module.config.js`, which seems less accurate than just referring to the main object that gets mounted as the module itself.

This PR also includes the initial commit of `API.md`, as outline in #380, with the `mountFieldModule` change included.