### PR TITLE
Support multiple FarmDateTimeForm components on a single page

### DIFF
--- a/src/components/FarmDateTimeForm.vue
+++ b/src/components/FarmDateTimeForm.vue
@@ -7,7 +7,7 @@
         type="date"
         :value="time.date"
         @input="updateDate($event.target.value)"
-        :required="!!timestamp"
+        :required="required"
         class="form-control">
     </div>
     <div :id="id + '-hour-form'" class="form-item form-group col">
@@ -80,6 +80,10 @@ export default {
     id: {
       default: 'date',
       type: String,
+    },
+    required: {
+      default: true,
+      type: Boolean,
     },
   },
   data() {

--- a/src/components/FarmDateTimeForm.vue
+++ b/src/components/FarmDateTimeForm.vue
@@ -1,19 +1,19 @@
 <template>
   <div class="farm-date-time-form form-row">
-    <div id="date-form" class="form-item form-group col">
-      <label for="date" class="control-label">{{ dateLabel }}</label>
+    <div :id="id + '-date-form'" class="form-item form-group col">
+      <label :for="id + '-date'" class="control-label">{{ dateLabel }}</label>
       <input
-        id="date"
+        :id="id + '-date'"
         type="date"
         :value="time.date"
         @input="updateDate($event.target.value)"
         required
         class="form-control">
     </div>
-    <div id="hour-form" class="form-item form-group col">
-      <label for="hour" class="control-label">Hour</label>
+    <div :id="id + '-hour-form'" class="form-item form-group col">
+      <label :for="id + '-hour'" class="control-label">Hour</label>
       <input
-        id="hour"
+        :id="id + '-hour'"
         type="number"
         min="1"
         max="12"
@@ -22,10 +22,10 @@
         @blur="updateHour($event.target.value, true)"
         class="form-control">
     </div>
-    <div id="minute-form" class="form-item form-group col">
-      <label for="minute" class="control-label">Min</label>
+    <div :id="id + '-minute-form'" class="form-item form-group col">
+      <label :for="id + '-minute'" class="control-label">Min</label>
       <input
-        id="minute"
+        :id="id + '-minute'"
         type="number"
         min="00"
         max="59"
@@ -34,30 +34,30 @@
         @blur="updateMinute($event.target.value, true)"
         class="form-control">
     </div>
-    <div id="am-pm-form" class="form-item form-group col">
-      <label for="am-pm" class="control-label"></label>
-      <div id="am-pm" class="form-item form-group">
+    <div :id="id + '-am-pm-form'" class="form-item form-group col">
+      <label :for="id + '-am-pm'" class="control-label"></label>
+      <div :id="id + '-am-pm'" class="form-item form-group">
         <div class="form-check">
           <input
-            id="is-am"
-            name="am-pm"
+            :id="id + '-is-am'"
+            :name="id + '-am-pm'"
             type="radio"
             value="am"
             :checked="time.am"
             @input="updateAmPm($event.target.checked)"
             class="form-check-input">
-          <label for="is-am" class="form-check-label">AM</label>
+          <label :for="id + '-is-am'" class="form-check-label">AM</label>
         </div>
         <div class="form-check">
           <input
-            id="is-pm"
-            name="am-pm"
+            :id="id + '-is-pm'"
+            :name="id + '-am-pm'"
             type="radio"
             value="pm"
             :checked="!time.am"
             @input="updateAmPm(!$event.target.checked)"
             class="form-check-input">
-          <label for="is-pm" class="form-check-label">PM</label>
+          <label :for="id + '-is-pm'" class="form-check-label">PM</label>
         </div>
       </div>
     </div>
@@ -75,6 +75,10 @@ export default {
     },
     dateLabel: {
       default: 'Date',
+      type: String,
+    },
+    id: {
+      default: 'date',
       type: String,
     },
   },

--- a/src/components/FarmDateTimeForm.vue
+++ b/src/components/FarmDateTimeForm.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="farm-date-time-form form-row">
     <div id="date-form" class="form-item form-group col">
-      <label for="date" class="control-label">Date</label>
+      <label for="date" class="control-label">{{ dateLabel }}</label>
       <input
         id="date"
         type="date"
@@ -69,7 +69,15 @@ const addLeadZero = d => ((d < 10) ? `0${d}` : d);
 
 export default {
   name: 'FarmDateTimeForm',
-  props: ['timestamp'],
+  props: {
+    timestamp: {
+      default: '',
+    },
+    dateLabel: {
+      default: 'Date',
+      type: String,
+    },
+  },
   data() {
     return {
       time: {

--- a/src/components/FarmDateTimeForm.vue
+++ b/src/components/FarmDateTimeForm.vue
@@ -7,7 +7,7 @@
         type="date"
         :value="time.date"
         @input="updateDate($event.target.value)"
-        required
+        :required="!!timestamp"
         class="form-control">
     </div>
     <div :id="id + '-hour-form'" class="form-item form-group col">

--- a/src/components/FarmDateTimeForm.vue
+++ b/src/components/FarmDateTimeForm.vue
@@ -93,6 +93,13 @@ export default {
   },
   methods: {
     updateInputFields(timestamp) {
+      if (!timestamp) {
+        this.time.date = '';
+        this.time.hour = '';
+        this.time.minute = '';
+        this.time.am = '';
+        return;
+      }
       this.time.date = this.unixToDateString(timestamp);
       const date = new Date(timestamp * 1000);
       const hours = date.getHours();


### PR DESCRIPTION
- Allow a custom `dateLabel` to replace the "Date" label of the component. This allows for multiple FarmDateTimeForm components to be added and labeled for their respective uses eg: "Start Date" and "End Date"
- Allow the date, hour and minute input fields to be empty if the provided `timestamp` is `null`. This improves behavior for forms where the date is optional - currently a null `timestamp` is displayed as `Dec 31 1970` in the form. Once the user provides input, a new `timestamp` is provided.
- Add an `id` to all form elements so that that multiple FarmDateTimeForm components have unique form elements on the same page. This fixes an issue where the AM/PM radio input was not unique to a single component. (@jgaehring I believe I implemented this correctly? Let me know if not!)