### PR TITLE
Make assets available to Field Module widgets via the assets prop.

### DIFF
--- a/src/core/home/Home.vue
+++ b/src/core/home/Home.vue
@@ -1,7 +1,7 @@
 <template>
   <div id="home">
     <div class="container-fluid">
-      <home-widgets :modules="modules" :logs="sortedLogs"/>
+      <home-widgets :modules="modules" :logs="sortedLogs" :assets="assets"/>
     </div>
   </div>
 </template>
@@ -17,6 +17,10 @@ const HomeWidgets = Vue.component('home-widgets', { // eslint-disable-line no-un
     },
     logs: {
       type: Object,
+      required: true,
+    },
+    assets: {
+      type: Array,
       required: true,
     },
   },
@@ -44,7 +48,7 @@ const HomeWidgets = Vue.component('home-widgets', { // eslint-disable-line no-un
           createElement('h4', module.label),
           createElement(
             `${module.name}-widget`,
-            { props: { logs: this.logs[module.name] || [] } },
+            { props: { logs: this.logs[module.name] || [], assets: this.assets } },
           ),
         ],
       )),
@@ -54,7 +58,7 @@ const HomeWidgets = Vue.component('home-widgets', { // eslint-disable-line no-un
 
 export default {
   name: 'Home',
-  props: ['modules', 'logs'],
+  props: ['modules', 'logs', 'assets'],
   created() {
     this.$store.dispatch('loadHomeCachedLogs');
   },

--- a/src/core/home/Home.vue
+++ b/src/core/home/Home.vue
@@ -48,7 +48,7 @@ const HomeWidgets = Vue.component('home-widgets', { // eslint-disable-line no-un
           createElement('h4', module.label),
           createElement(
             `${module.name}-widget`,
-            { props: { logs: this.logs[module.name] || [], assets: this.assets } },
+            { props: { logs: this.logs[module.name] || [], assets: this.assets || [] } },
           ),
         ],
       )),


### PR DESCRIPTION
Would like to display the current number of sensors in the Sensors Field Module widget! This seems to make that possible; @jgaehring let me know if there is a better way? Curious about making other things such as `areas` available as well.

I'm trying to see how this is done for the main Field Module component as it seems like all props are made available to those components, but its not as obvious. Does this happen in `createRoutes` when the Field Module is created?