### PR TITLE
Disable files and images on v1

### DIFF
--- a/src/field-modules/tasks/components/TasksEdit.vue
+++ b/src/field-modules/tasks/components/TasksEdit.vue
@@ -375,41 +375,51 @@
 
       <farm-card>
         <h3>{{ $t('Images')}}</h3>
-        <div
-          v-if="isNative"
-          class="form-item form-item-name form-group">
-          <button
-            :disabled='false'
-            title="Take picture with camera"
-            @click="getPhoto"
-            class="btn btn-info btn-navbar navbar-right"
-            type="button">
-            {{ $t('Take picture with camera')}}
-          </button>
+        <div v-if="currentLog.id">
+          <p>
+            {{ $t('To prevent data loss, images have been disabled for logs ') }}
+            {{ $t('that have already been uploaded to the server, because ') }}
+            {{ $t('there is a risk that they could overwrite existing images. ') }}
+            {{ $t('We are working to fix this in Field Kit v2.') }}
+          </p>
         </div>
-        <div class="form-item form-item-name form-group">
-          <div class="input-group ">
-            <label
-              class="custom-file-label"
-              for="customFile">
-              {{ $t('Select photo from file')}}
-            </label>
-            <input
-              type="file"
-              accept="image/*"
-              class="custom-file-input"
-              ref="photo"
-              @change="loadPhoto($event.target.files)">
+        <div v-if="!currentLog.id">
+          <div
+            v-if="isNative"
+            class="form-item form-item-name form-group">
+            <button
+              :disabled='false'
+              title="Take picture with camera"
+              @click="getPhoto"
+              class="btn btn-info btn-navbar navbar-right"
+              type="button">
+              {{ $t('Take picture with camera')}}
+            </button>
           </div>
-        </div>
-        <div class="form-item form-item-name form-group">
-          <!-- NOTE: Display is set to 'none' if the img fails to load. -->
-          <img
-            v-for="(url, i) in imageUrls"
-            :src="url"
-            :key="`preview-${i}`"
-            onerror="this.style.display='none'"
-            class="preview" />
+          <div class="form-item form-item-name form-group">
+            <div class="input-group ">
+              <label
+                class="custom-file-label"
+                for="customFile">
+                {{ $t('Select photo from file')}}
+              </label>
+              <input
+                type="file"
+                accept="image/*"
+                class="custom-file-input"
+                ref="photo"
+                @change="loadPhoto($event.target.files)">
+            </div>
+          </div>
+          <div class="form-item form-item-name form-group">
+            <!-- NOTE: Display is set to 'none' if the img fails to load. -->
+            <img
+              v-for="(url, i) in imageUrls"
+              :src="url"
+              :key="`preview-${i}`"
+              onerror="this.style.display='none'"
+              class="preview" />
+          </div>
         </div>
       </farm-card>
 

--- a/src/utils/farmLog.js
+++ b/src/utils/farmLog.js
@@ -204,6 +204,8 @@ function farmLog(logTypes) {
       delete serverLog.localID;
       delete serverLog.url;
       if (serverLog.id === undefined) { delete serverLog.id; }
+      // Prevent images on the server from being overwritten, b/c issue #444.
+      if (serverLog.id) { delete serverLog.images; }
       return serverLog;
     },
     mergeLogFromServer(localLog, serverLog) {


### PR DESCRIPTION
In response to #444, this PR will do 2 things:

1. Remove the `files` field from all logs.
2. Disable the ability to add images to any logs that have already been synced to the server. The `images` field will be stripped off logs before sending them to the server if a server-assigned `id` is present on the log.

Number 2 introduces a significant restriction of the images feature, but I think this is necessary until we overhaul images (#45), which will probably only be implemented in version 2.x. So this will be a permanent limitation in 1.x. Included in this PR is an explanation of why we're restricting this feature, which will be displayed on logs that have already been synced.