### PR TITLE
Replace App.vue w/ shutdown notice.

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -4,7 +4,7 @@
   "theme_color": "#336633",
   "background_color": "#ffffff",
   "display": "standalone",
-  "Scope": "/",
+  "scope": "/",
   "start_url": "/",
   "icons": [
     {

--- a/src/core/ShutdownNotice.vue
+++ b/src/core/ShutdownNotice.vue
@@ -1,0 +1,36 @@
+<template>
+  <div class="module-container">
+    <farm-main :paddingTop="['xl', 'xxl']" :paddingX="['l', 'xxl']">
+
+      <farm-stack space="l">
+        <farm-card>
+          <h3 class="card-title">Shutdown Notice</h3>
+          <p class="card-text">
+            farmos.app is down for maintenance in preparation for the upcoming
+            release of Field Kit Version 2. If you wish to continue using
+            Version 1, please go to
+            <a href="https://v1.farmos.app" target="_blank">
+              v1.farmos.app
+            </a>
+            to reinstall. For more information, visit
+            <a href="https://farmos.discourse.group/t/migrating-from-farmos-app-to-v1-farmos-app/791" target="_blank">
+              the farmOS forum
+            </a>.
+          </p>
+        </farm-card>
+      </farm-stack>
+
+    </farm-main>
+  </div>
+</template>
+
+<script>
+
+export default {
+  name: 'ShutdownNotice',
+};
+</script>
+
+<style scoped>
+
+</style>

--- a/src/core/app.js
+++ b/src/core/app.js
@@ -1,67 +1,15 @@
 import Vue from 'vue';
-import wellknown from 'wellknown';
-import farm from './store/farmClient';
-import router from './router';
-import store from './store';
-import App from './App.vue'; // eslint-disable-line import/extensions
+import ShutdownNotice from './ShutdownNotice.vue'; // eslint-disable-line import/extensions
 import './normalize.css';
 import './bootstrap-simplex.min.css';
 import './vars.css';
 import './main.css';
-import utils from '../utils';
-import { createFieldModule, loadFieldModule, setRootRoute } from '../utils/fieldModules';
 import components from '../components';
-import t from './mixins/t';
 
-Vue.config.productionTip = false;
-
-// Attach utils to the global namespace so Field Modules can access them.
-if (window.farmOS === undefined) {
-  window.farmOS = {};
-}
-window.farmOS.utils = utils;
-window.farmOS.lib = {
-  wellknown,
-};
-
-// Register the shared component library globally so they can be accessed from
-// any other component on the root Vue instance.
 components.forEach((c) => { Vue.component(c.name, c); });
 
-// Globally apply the t mixin, which provides translations along with the l10n module
-Vue.mixin(t);
-
-// Provide a global function for mounting Field Modules with all its dependencies.
-const deps = { ...store, state: store.state, router };
-window.farmOS.mountFieldModule = mod => createFieldModule(mod, deps);
-
-export default (el, buildtimeMods) => {
-  // Load build-time modules
-  if (buildtimeMods !== undefined && buildtimeMods.length > 0) {
-    buildtimeMods.forEach(mod => createFieldModule(mod, deps));
-  }
-
-  farm().info()
-    .then((res) => {
-      if (res?.client?.modules) {
-        Object.values(res.client.modules).forEach(loadFieldModule);
-        localStorage.setItem('modules', JSON.stringify(res.client.modules));
-      }
-      setRootRoute(res?.client?.modules, router);
-    })
-    // If the request fails, we can still load modules from cache.
-    .catch(() => {
-      const modules = JSON.parse(localStorage.getItem('modules'));
-      if (modules) {
-        Object.values(modules).forEach(loadFieldModule);
-      }
-      setRootRoute(modules, router);
-    })
-    .finally(() => new Vue({
-      el,
-      store,
-      router,
-      components: { App },
-      template: '<App/>',
-    }));
-};
+export default el => new Vue({
+  el,
+  components: { ShutdownNotice },
+  template: '<ShutdownNotice/>',
+});

--- a/src/main.js
+++ b/src/main.js
@@ -1,10 +1,7 @@
 import app from './core/app';
-import tasks from './field-modules/tasks/module';
 import onupdatefound from './onupdatefound';
 
-app('#app', [
-  tasks,
-]);
+app('#app');
 
 // Check that service workers are registered (for production environment only)
 if ('serviceWorker' in navigator && process.env.NODE_ENV === 'production') {


### PR DESCRIPTION
See https://github.com/farmOS/field-kit/issues/421#issuecomment-1034051557.

This will replace the entire app with a simple screen that reads:

>  farmos.app is down for maintenance in preparation for the upcoming release of Field Kit Version 2. If you wish to continue using Version 1, please go to <a href="https://v1.farmos.app" target="_blank">v1.farmos.app</a> to reinstall. For more information, visit <a href="https://farmos.discourse.group/t/migrating-from-farmos-app-to-v1-farmos-app/791" target="_blank">the farmOS forum</a>.

Data will not be lost, but won't be easily retrievable if it has not been already synced to the server. Hopefully there has been ample warning time (over a year) and this won't be an issue.