### PR TITLE
Link quantities

### DIFF
--- a/packages/field-kit/src/entities/index.js
+++ b/packages/field-kit/src/entities/index.js
@@ -195,6 +195,17 @@ export default function useEntities(options = {}) {
     return itemReference;
   }
 
+  // Remove an entity from a collection of entities. This discards any pending
+  // revisions, but does not delete the entity from local or remote persistence.
+  function drop(collectionReference, id) {
+    const collection = collections.get(collectionReference);
+    const { state: collectionState } = collection;
+    const i = collectionState.findIndex(item => item.id === id);
+    const itemRef = collectionReference[i];
+    collectionState.splice(i, 1);
+    return itemRef;
+  }
+
   // Upsert an entity in the collection.
   const emitCollection = reference => (value = {}) => {
     const { id, type, ...fields } = value;
@@ -317,6 +328,6 @@ export default function useEntities(options = {}) {
   }
 
   return {
-    add, append, checkout, commit, revise,
+    add, append, checkout, commit, drop, revise,
   };
 }

--- a/packages/field-kit/src/entities/index.js
+++ b/packages/field-kit/src/entities/index.js
@@ -2,23 +2,25 @@ import {
   isProxy, isRef, reactive, readonly, ref, shallowReactive, unref, watch, watchEffect,
 } from 'vue';
 import {
-  clone, complement, compose, curryN, equals, is, none, propEq,
+  assoc, clone, complement, compose, curryN, equals, is,
+  map, mapObjIndexed, pick, propEq, when,
 } from 'ramda';
 import { validate, v4 as uuidv4 } from 'uuid';
 import { splitFilterByType } from 'farmos';
 import farm from '../farm';
 import router from '../router';
-import SyncScheduler from '../http/SyncScheduler';
+import { STATUS_IN_PROGRESS, updateStatus } from '../http/connection';
+import interceptor from '../http/interceptor';
 import { syncEntities } from '../http/sync';
+import SyncScheduler from '../http/SyncScheduler';
 import { getRecords } from '../idb';
 import { cacheEntity } from '../idb/cache';
-import flattenEntity from '../utils/flattenEntity';
 import asArray from '../utils/asArray';
-import { STATUS_IN_PROGRESS, updateStatus } from '../http/connection';
-import { alert } from '../warnings/alert';
-import interceptor from '../http/interceptor';
-import { PromiseQueue } from '../utils/promises';
+import diff from '../utils/diff';
 import parseFilter from '../utils/parseFilter';
+import { PromiseQueue } from '../utils/promises';
+import flattenEntity from '../utils/flattenEntity';
+import { alert } from '../warnings/alert';
 import nomenclature from './nomenclature';
 import {
   backupTransactions, clearBackup, restoreTransactions,
@@ -287,13 +289,27 @@ export default function useEntities(options = {}) {
     return reference;
   }
 
+  // A synchronous operation that updates the reference but does not persist
+  // that update in the local database or send it to any remote. Instead, it
+  // holds onto the transaction so it can be replayed by the commit function.
+  function revise(reference, transaction) {
+    let fields = {}; let tx = () => fields;
+    if (typeof transaction === 'function') tx = transaction;
+    if (is(Object, transaction)) fields = transaction;
+    const { state, transactions, backupURI } = revisions.get(reference);
+    fields = tx(reference);
+    transactions.push(tx);
+    backupTransactions(backupURI, fields);
+    emit(state, fields);
+  }
+
   // Checkout the entity or a collection of entities related to another that's
-  // already been checked out (ie, `origReference`). The linked reference will
+  // already been checked out (ie, `referent`). The linked reference will
   // be updated reactively if a resource identifier changes in the corresponding
-  // relationship field of the original reference.
-  function link(origRef, relationship, entity) {
-    if (!isProxy(origRef) && !isRef(origRef)) {
-      const msg = `Invalid reference while linking the ${relationship} relationship.`
+  // relationship field of the original referent.
+  function link(referent, relationship, entity) {
+    if (!isProxy(referent) && !isRef(referent)) {
+      const msg = `Invalid referent while linking the ${relationship} relationship.`
         + ' Provide a reference to another entity that has already been checked out,'
         + ' or use valid Vue ref or reactive object as a placeholder.';
       throw new Error(msg);
@@ -301,14 +317,21 @@ export default function useEntities(options = {}) {
     const state = ref(null);
     const linkedRef = readonly(state);
     revisions.set(linkedRef, { entity, state });
-    // Helper for updating changes to one-to-many relationships.
-    const ifMissing = (arrA = [], arrB = [], cb) => arrA.forEach((a) => {
-      if (none(propEq('id', a.id), arrB)) { cb(a); }
-    });
+    // This callback is a Vue watcher set on the original reference, or more
+    // specifically, on a getter for the particular relationship field on that
+    // origRef. When called, it updates the state of the linkedRef accordingly.
     const update = (next, prev) => {
-      if (!next && validate(prev?.id)) state.value = null;
+      const origRef = revisions.has(referent) ? referent : unref(referent);
+      const origRev = revisions.get(origRef);
+      if (!is(Map, origRev.dependencies)) origRev.dependencies = new Map();
+      if (!next && validate(prev?.id)) {
+        origRev.dependencies.delete(state.value);
+        state.value = null;
+      }
       if (validate(next?.id) && next.id !== prev?.id) {
+        origRev.dependencies.delete(state.value);
         state.value = checkout(entity, next.type, prev.id);
+        origRev.dependencies.set(state.value, relationship);
         // After setting the state, "unwrap" the new revision data too, by swapping
         // it for all but the previous revision's state and unwatch callback, then
         // setting it to the linked reference. This obviates the need to unwrap the
@@ -317,39 +340,59 @@ export default function useEntities(options = {}) {
         revisions.set(linkedRef, revision);
       }
       if ([origRef?.[relationship], state.value, next].some(Array.isArray)) {
-        if (!collections.has(linkedRef)) {
-          const filter = next?.reduce((acc, { id, type }) => {
-            const i = acc.findIndex(f => f.type === type);
-            if (i < 0) return [...acc, { type, id: [id] }];
-            const ids = acc[i]?.id || [];
-            return [
-              ...acc.slice(0, i),
-              { type, id: [...ids, id] },
-              ...acc.slice(i + 1),
-            ];
-          }, []) || [];
+        if (!collections.has(state.value)) {
+          const filter = map(pick(['id', 'type']), next || []);
           const nextRef = checkoutCollection(entity, filter);
           state.value = nextRef;
           const collection = collections.get(nextRef);
           collections.set(state.value, collection);
         }
-        ifMissing(next, prev, n => append(state.value, n.type, n));
-        ifMissing(prev, next, p => drop(state.value, p.id));
+        const [additions, removals, indices] = diff((p, n) => p.id === n.id, prev, next);
+        removals.forEach((r) => {
+          // When the previous id was null or invalid, there's nothing to drop.
+          if (validate(r.id)) {
+            const droppedRef = drop(state.value, r.id);
+            origRev.dependencies.delete(droppedRef);
+          }
+        });
+        const nullIndices = [];
+        additions.forEach((a, j) => {
+          if (validate(a.id)) {
+            const appendedRef = append(state.value, a.type, a);
+            origRev.dependencies.set(appendedRef, relationship);
+          } else {
+            const i = indices[j];
+            nullIndices.push(i);
+          }
+        });
+        // When a null or invalid id is provided, the id must be set manually on
+        // the original referent, without appending. That will trigger update to
+        // be called again, and on the second try it WILL validate and the ref
+        // will be appended once and only once. Otherwise, trying to append AND
+        // set the original referent's state in the same call would result in a
+        // double append.
+        if (nullIndices.length > 0) {
+          const withIds = next.map((n, i) => {
+            if (!nullIndices.includes(i)) return n;
+            return { ...n, id: uuidv4() };
+          });
+          revise(origRef, { [relationship]: withIds });
+        }
       }
     };
     // To make sure the linkedRef gets updates whenever there are changes to the
     // corresponding resource identifiers in the origRef, a watcher must be set.
     let watcherIsSet = false;
     const setLinkWatcher = () => {
-      const proxy = unref(origRef);
+      const origRef = revisions.has(referent) ? referent : unref(referent);
       // The original ref might be null or undefined initially, so check first.
-      if (revisions.has(proxy) && relationship in proxy && !watcherIsSet) {
-        const getter = () => proxy[relationship];
+      if (revisions.has(origRef) && relationship in origRef && !watcherIsSet) {
+        const getter = () => origRef[relationship];
         linkWatchers.set(linkedRef, {
           watch: update,
           unwatch: watch(getter, update, { deep: true }),
         });
-        update(proxy[relationship]);
+        update(origRef[relationship]);
         watcherIsSet = true;
       }
     };
@@ -368,32 +411,19 @@ export default function useEntities(options = {}) {
     if (watcher && typeof watcher.unwatch === 'function') watcher.unwatch();
   }
 
-  // A synchronous operation that updates the reference but does not persist
-  // that update in the local database or send it to any remote. Instead, it
-  // holds onto the transaction so it can be replayed by the commit function.
-  function revise(reference, transaction) {
-    let fields = {}; let tx = () => fields;
-    if (typeof transaction === 'function') tx = transaction;
-    if (is(Object, transaction)) fields = transaction;
-    const { state, transactions, backupURI } = revisions.get(reference);
-    fields = tx(reference);
-    transactions.push(tx);
-    backupTransactions(backupURI, fields);
-    emit(state, fields);
-  }
-
   // An ASYNCHRONOUS operation, which replays all transactions based on the
   // current state of the entity at the time of calling, then writes those
   // changes to the local database and sends them on to remote systems.
   function commit(reference) {
-    if (is(Array, reference)) {
-      return Promise.allSettled(reference.map(commit));
+    if (is(Array, reference) || is(Array, unref(reference))) {
+      const allCommits = reference?.map(commit) || unref(reference).map(commit);
+      return Promise.allSettled(allCommits);
     }
-    const revision = revisions.get(reference);
+    const revision = revisions.get(reference) || revisions.get(unref(reference));
     const transactions = [...revision.transactions];
     revision.transactions = [];
     const {
-      entity, type, id, queue, state, backupURI,
+      entity, type, id, queue, state, backupURI, dependencies,
     } = revision;
     const { shortName } = nomenclature.entities[entity];
     return queue.push((previous) => {
@@ -403,13 +433,55 @@ export default function useEntities(options = {}) {
       // have received updates from a previous commit, so make sure to update it.
       emit(state, fields);
       const next = farm[shortName].update(previous, fields);
-      return cacheEntity(entity, next).then(() => {
-        clearBackup(backupURI);
-        const syncOptions = { cache: asArray(next), filter: { id, type } };
-        return syncEntities(shortName, syncOptions)
-          .then(syncHandler(revision))
-          .then(({ data: [value] = [] } = {}) => value);
-      });
+      return cacheEntity(entity, next)
+        .then(() => {
+          clearBackup(backupURI);
+          if (!is(Map, dependencies)) return Promise.resolve({});
+          // Dependent fields, created as relationships by the link function above,
+          // must have their corresponding entities committed first.
+          const dependentCommits = Array.from(dependencies)
+            .filter(([, relationship]) => relationship in fields)
+            .map(([depRef, relationship]) => commit(depRef)
+              // Key each response to its original relationship, so it can be
+              // mapped to its corresponding field, updating it in the process.
+              .then(response => [relationship, response]));
+          // Then Promise.all will resolve to an array of key/val pairs, which
+          // can be transformed to an object for easier mapping below.
+          return Promise.all(dependentCommits)
+            .then(Object.fromEntries);
+        })
+        .then(mapObjIndexed((response, relationship) => {
+          // Most dependent fields, especially quantities, require the revision
+          // metadata be included in the relationship field, so those internal
+          // Drupal attributes must be mapped to their corresponding resource
+          // identifiers in the entity being committed here. Oy vey.
+          const {
+            drupal_internal__revision_id: target_revision_id,
+            drupal_internal__id: drupal_internal__target_id,
+          } = response.meta?.remote?.meta?.attributes || {};
+          if (!drupal_internal__target_id) return fields[relationship];
+          const meta = { target_revision_id, drupal_internal__target_id };
+          // Add metadata to a single resource identifier.
+          const addMetaData = assoc('meta', meta);
+          // Add metadata to a resource identifier in a one-to-many relationship.
+          const insertMetaData = map(when(propEq('id', response.id), addMetaData));
+          return Array.isArray(fields[relationship])
+            ? insertMetaData(fields[relationship]) // one-to-many
+            : addMetaData(fields[relationship]); // one-to-one
+        }))
+        .then((finalFields) => {
+          // Early return for an empty fields object.
+          if (Object.keys(finalFields).length === 0) return next;
+          // Emit and update one last time with those fields and their metadata.
+          emit(state, finalFields);
+          return farm[shortName].update(next, finalFields);
+        })
+        .then((final) => {
+          const syncOptions = { cache: asArray(final), filter: { id, type } };
+          return syncEntities(shortName, syncOptions);
+        })
+        .then(syncHandler(revision))
+        .then(({ data: [value] = [] } = {}) => value);
     });
   }
 

--- a/packages/field-kit/src/entities/index.js
+++ b/packages/field-kit/src/entities/index.js
@@ -178,14 +178,20 @@ export default function useEntities(options = {}) {
     return [reference, revision];
   }
 
+  // Create a reference to a single entity without yet committing it.
+  function add(entity, type, fields = {}) {
+    const [reference, revision] = createEntity(entity, type, fields?.id);
+    const { queue, state: itemState } = revision;
+    queue.push(() => emit(itemState, fields));
+    return reference;
+  }
+
   // Create a new entity and add it to an existing collection.
   function append(collectionReference, type, fields) {
     const collection = collections.get(collectionReference);
     const { entity, state: collectionState } = collection;
-    const [itemReference, revision] = createEntity(entity, type, fields?.id);
+    const itemReference = add(entity, type, fields);
     collectionState.push(itemReference);
-    const { queue, state: itemState } = revision;
-    queue.push(() => emit(itemState, fields));
     return itemReference;
   }
 
@@ -311,6 +317,6 @@ export default function useEntities(options = {}) {
   }
 
   return {
-    append, checkout, commit, revise,
+    add, append, checkout, commit, revise,
   };
 }

--- a/packages/field-kit/src/idb/cache.js
+++ b/packages/field-kit/src/idb/cache.js
@@ -1,5 +1,5 @@
 import { useRouter } from 'vue-router';
-import { anyPass, complement } from 'ramda';
+import { anyPass, complement, is } from 'ramda';
 import farm from '../farm';
 import nomenclature from '../entities/nomenclature';
 import {
@@ -33,19 +33,98 @@ export const cachingCriteria = (options = {}) => {
       },
     },
     plan: {},
-    quantity: {},
+    quantity: false,
     taxonomy_term: {},
     user: { id: uid },
   };
+};
+
+// These batches establish the order in which entities are synced and purged.
+// Some entities (eg, quantities) depend upon others (eg, logs) to generate a
+// passlist based on the latter's caching status and whether or not any of the
+// former entities are related to it. So in the case of quantities, there are
+// too many to just cache them all (unlike terms), but no criteria in the entity
+// data itself, such as a timestamp, upon which to judge if it should be cached.
+// A quantity's status is contingent on whether any logs have already been
+// cached that reference the quantity in its `quantity` relationship field. So
+// as logs are being cached or purged in the first batch, their `quantity` field
+// is checked for any quantities
+const batches = [[
+  'asset',
+  'log',
+  'plan',
+  'taxonomy_term',
+  'user',
+], [
+  'quantity',
+]];
+// Each passlist is a Map from an entity's id (UUID) to a Set of id's for any
+// other entity that depends upon it. Empty sets will be deleted, so whether or
+// not an entity is the dependency of another entity (or several others) can be
+// determined, as in isDependency() below simply by calling Map.prototype.has().
+const passlists = {
+  quantity: new Map(),
+};
+// A collection of mappings from the relationship field of a higher order batch,
+// to the entity name of a lower order batch the former's field depends on.
+const dependencyLists = {
+  log: new Map([
+    // relationship => entity name
+    ['quantity', 'quantity'],
+  ]),
+};
+
+function listDependencies(name, entity) {
+  const dependencies = dependencyLists[name];
+  if (is(Map, dependencies)) {
+    dependencies.forEach((depName, relationship) => {
+      const list = passlists[depName];
+      const add = (dep) => {
+        if (!list.has(dep.id)) list.set(dep.id, new Set());
+        const set = list.get(dep.id);
+        set.add(entity.id);
+      };
+      const field = entity?.relationships?.[relationship];
+      if (Array.isArray(field)) field.forEach(add);
+      if (field.id) add(field);
+    });
+  }
+}
+
+const unlistDependencies = name => (results) => {
+  const dependencies = dependencyLists[name];
+  if (!is(Map, dependencies)) return results;
+  const { deleted = [] } = results;
+  deleted.forEach((entity) => {
+    dependencies.forEach((depName, relationship) => {
+      const list = passlists[depName];
+      const remove = (dep) => {
+        const set = list.get(dep.id);
+        set?.delete(entity.id);
+        if (set.size <= 0) list.delete(dep.id);
+      };
+      const field = entity?.relationships?.[relationship];
+      if (Array.isArray(field)) field.forEach(remove);
+      if (field.id) remove(field);
+    });
+  });
+  return results;
+};
+
+const isDependency = name => (entity) => {
+  if (name in passlists) return passlists[name].has(entity.id);
+  return false;
 };
 
 export const cacheEntity = (name, entity, options) => {
   const criteria = cachingCriteria(options)[name];
   const meetsCriteria = anyPass([
     parseFilter(criteria),
+    isDependency(name),
     farm.meta.isUnsynced,
   ]);
   if (meetsCriteria(entity)) {
+    listDependencies(name, entity);
     return saveRecord('entities', name, entity)
       // b/c saveRecord just returns the uuid
       .then(() => entity);
@@ -53,59 +132,52 @@ export const cacheEntity = (name, entity, options) => {
   return Promise.resolve(entity);
 };
 
-export const purgeCache = () => {
+const purgeCache = (batch) => {
   const criteria = cachingCriteria();
   const meetsCriteria = name => complement(anyPass([
     parseFilter(criteria[name]),
+    isDependency(name),
     farm.meta.isUnsynced,
   ]));
-  const dbRequests = Object.keys(nomenclature.entities)
-    .map(name => deleteRecord('entities', name, meetsCriteria(name)));
-  return Promise.all(dbRequests);
+  return Promise.all(batch.map(name =>
+    deleteRecord('entities', name, meetsCriteria(name))
+      .then(unlistDependencies(name))));
 };
 
 function syncHandler(evaluation) {
   const {
-    loginRequired,
-    connectivity,
-    alerts,
+    loginRequired, connectivity, alerts,
   } = evaluation;
   updateStatus(connectivity);
-  if (alerts.length > 0) {
-    alert(alerts);
-  }
-  if (loginRequired) {
-    const router = useRouter();
-    router.push('/login');
-  }
+  if (alerts.length > 0) alert(alerts);
+  if (loginRequired) useRouter().push('/login');
 }
 
-export const syncCache = async () => {
+// A batch of one or more entities, listed by name, is synced in parallel via
+// Promise.allSettled. First, the cache is checked for any prexisting records,
+// then a sync request is made that merges and caches any remote results.
+const syncCache = async (batch) => {
   const now = new Date().toISOString();
   const settings = JSON.parse(LS.getItem('cacheSettings')) || {};
   const { lastSync } = settings;
-  const requests = Object.values(nomenclature.entities).map(async ({ name, shortName }) => {
+  const requests = batch.map(async (name) => {
+    const { shortName } = nomenclature.entities[name];
     const criteria = cachingCriteria({ now })[name];
     const changed = { $gt: lastSync };
     const filter = changed.$gt ? { ...criteria, changed } : criteria;
-    const cache = await getRecords('entities', name);
+    const cache = await getRecords('entities', name, parseFilter(criteria));
     updateStatus(STATUS_IN_PROGRESS);
     const syncResults = await syncEntities(shortName, { filter, cache, limit: Infinity });
-    const cacheRequests = syncResults.data.map(e => cacheEntity(name, e, criteria));
+    const cacheRequests = syncResults.data.map(d => cacheEntity(name, d, criteria));
     const cacheResults = await Promise.allSettled(cacheRequests);
-    const failedToCache = cacheResults.some(({ status }) => status === 'rejected');
-    if (failedToCache) {
-      cacheResults.forEach(({ status, reason }, i) => {
-        if (status === 'rejected') {
-          const data = syncResults.data[i];
-          const error = new Error(
-            `Error caching ${shortName} "${data.name}": ${reason.message}`,
-            { cause: reason },
-          );
-          alert(error);
-        }
-      }, []);
-    }
+    cacheResults.forEach(({ status, reason }, i) => {
+      if (status === 'rejected') {
+        let label = syncResults.data[i]?.name || syncResults.data[i]?.label;
+        label = label ? ` "${label}" ` : '';
+        const msg = `Error caching ${shortName}${label}: ${reason.message}`;
+        alert(new Error(msg, { cause: reason }));
+      }
+    });
     return interceptor(syncHandler, syncResults);
   });
   return Promise.allSettled(requests).then(() => {
@@ -114,4 +186,8 @@ export const syncCache = async () => {
   });
 };
 
-export const refreshCache = () => syncCache().then(purgeCache);
+const refresh = ([head, ...tail]) => syncCache(head)
+  .then(() => purgeCache(head))
+  .then(result => (tail.length > 0 ? refresh(tail) : result));
+
+export const refreshCache = () => refresh(batches);

--- a/packages/field-kit/src/utils/diff.js
+++ b/packages/field-kit/src/utils/diff.js
@@ -1,0 +1,47 @@
+import {
+  addIndex, curryN, map, reduce, remove,
+} from 'ramda';
+
+// Map any array to its index numbers, eg, ['foo', 'bar', 'bax'] => [0, 1, 2].
+// This is used to keep track of the original index of items as they are diffed.
+const toIndices = addIndex(map)((_, i) => i);
+
+/**
+ * @typedef {Function} diff A utility for comparing two arrays of items, helpful
+ * for finding changes in a list from a previous state to the next. Using a
+ * predicate function, it iterates through all items in both lists looking for
+ * matches between the two lists. It returns a tuple of four lists, additions,
+ * removals, and two lists of indices: the first list, additions, contains all
+ * items that were not included in the previous list (2nd param) but were
+ * included in the next list (3rd param), while the second list in the tuple,
+ * removals, contains all items that were included in the previous list but not
+ * in the next. The last two lists contain the original indices of the items in
+ * the additions and removals lists, respectively.
+ * @template T An item from either list, likely an object with id or primary key.
+ * @param {(prev: T, nx: T) => Boolean} predicate A predicate function that takes
+ * an item from the previous list as its first param and an item from the next
+ * list to evaluate if they are equivalent and return true if so.
+ * @param {[T]} previous An array of items representing the previous state.
+ * @param {[T]} next An array of items representing the next state.
+ * @returns {[[T], [T], [Number], [Number]]}
+ */
+const diff = curryN(3, (predicate, previous = [], next = []) =>
+  addIndex(reduce)(([additions, removals, is, js], nx, i) => {
+    const j = removals.findIndex(pre => predicate(pre, nx));
+    if (j >= 0) {
+      return [
+        additions,
+        remove(j, 1, removals),
+        is,
+        remove(j, 1, js),
+      ];
+    }
+    return [
+      [...additions, nx],
+      removals,
+      [...is, i],
+      js,
+    ];
+  }, [[], previous, [], toIndices(previous)], next));
+
+export default diff;

--- a/packages/field-kit/src/utils/fraction.js
+++ b/packages/field-kit/src/utils/fraction.js
@@ -1,0 +1,25 @@
+export const gcd = (a, b) => (b > Number.EPSILON ? gcd(b, a % b) : a);
+export function toFraction(string) {
+  const decimal = Number.parseFloat(string);
+  if (Number.isInteger(decimal)) {
+    return {
+      numerator: decimal,
+      denominator: 1,
+      decimal,
+    };
+  }
+  const int = Number.parseInt(string, 10);
+  const places = (decimal - int).toString(10).length - 2;
+  let denominator = Math.abs(10 ** places);
+  let numerator = decimal * denominator;
+  const divisor = gcd(numerator, denominator);
+  denominator /= divisor;
+  numerator /= divisor;
+  return { numerator, denominator, decimal };
+}
+
+export function toDecimal(value) {
+  if (!value || typeof value !== 'object') return 0;
+  const { decimal, numerator, denominator } = value;
+  return decimal || numerator / denominator;
+}

--- a/packages/field-kit/src/utils/index.js
+++ b/packages/field-kit/src/utils/index.js
@@ -1,5 +1,7 @@
 // Only these utilities are exposed to field modules on the window.lib global namespace.
+export { default as daysAway } from './daysAway';
+export { default as diff } from './diff';
+export { gcd, toDecimal, toFraction } from './fraction';
 export { mergeGeometries, removeGeometry, isNearby } from './geometry';
 export { default as parseNotes } from './parseNotes';
-export { default as daysAway } from './daysAway';
 export { default as parseFilter } from './parseFilter';

--- a/packages/field-module-tasks/src/components/Tasks.vue
+++ b/packages/field-module-tasks/src/components/Tasks.vue
@@ -38,6 +38,13 @@ export default {
     const currentID = ref(logs[0]);
     const current = computed(() => logs.find(l => l.id === currentID.value));
 
+    const quantities = computed(() => {
+      if (!Array.isArray(current?.value?.quantity)) return [];
+      const filter = current.value.quantity.map(({ id, type }) => ({ id, type }));
+      return checkout('quantity', filter);
+    });
+    provide('quantities', { quantities });
+
     const open = (id) => {
       currentID.value = id;
       router.push({ path: '/tasks/edit' });

--- a/packages/field-module-tasks/src/components/Tasks.vue
+++ b/packages/field-module-tasks/src/components/Tasks.vue
@@ -33,7 +33,7 @@ export default {
   setup() {
     const router = useRouter();
     const {
-      add, append, checkout, commit, link, revise,
+      append, checkout, commit, link, revise,
     } = useEntities();
 
     const assetFilter = { status: 'active' };
@@ -71,12 +71,10 @@ export default {
 
     const quantities = link(current, 'quantity', 'quantity');
     const addQuantity = (type = 'quantity--standard') => {
-      const quantity = add('quantity', type);
-      const { id } = quantity;
       const resIds = current.value?.quantity || [];
-      const updatedResIds = [...resIds, { id, type }];
+      const updatedResIds = [...resIds, { id: null, type }];
       update({ quantity: updatedResIds });
-      return id;
+      return resIds.length;
     };
     const updateQuantity = (key, value, id) => {
       let v = value;
@@ -85,12 +83,11 @@ export default {
       const quantity = quantities.value.find(q => q.id === id);
       if (quantity) revise(quantity, { [key]: v });
     };
-    const removeQuantity = (id) => {
-      const i = current.value.quantity.findIndex(q => q.id === id);
-      if (i >= 0) {
+    const removeQuantity = (index) => {
+      if (index >= 0) {
         const quantity = [
-          ...current.value.quantity.slice(0, i),
-          ...current.value.quantity.slice(i + 1),
+          ...current.value.quantity.slice(0, index),
+          ...current.value.quantity.slice(index + 1),
         ];
         update({ quantity });
       }
@@ -99,8 +96,7 @@ export default {
       quantities, addQuantity, updateQuantity, removeQuantity,
     });
 
-    const save = () => commit(quantities.value)
-      .then(() => commit(current.value));
+    const save = () => commit(current.value);
     const close = () => {
       const request = commit(current.value);
       router.push({ path: '/tasks' });

--- a/packages/field-module-tasks/src/components/Tasks.vue
+++ b/packages/field-module-tasks/src/components/Tasks.vue
@@ -2,31 +2,11 @@
   <router-view/>
 </template>
 <script>
-const { useEntities } = window.lib;
+const { toFraction, useEntities } = window.lib;
 const {
   computed, ref, inject, provide,
 } = window.Vue;
 const { useRouter } = window.VueRouter;
-
-const gcd = (a, b) => (b > Number.EPSILON ? gcd(b, a % b) : a);
-function toFraction(string) {
-  const decimal = Number.parseFloat(string);
-  if (Number.isInteger(decimal)) {
-    return {
-      numerator: decimal,
-      denominator: 1,
-      decimal,
-    };
-  }
-  const int = Number.parseInt(string, 10);
-  const places = (decimal - int).toString(10).length - 2;
-  let denominator = Math.abs(10 ** places);
-  let numerator = decimal * denominator;
-  const divisor = gcd(numerator, denominator);
-  denominator /= divisor;
-  numerator /= divisor;
-  return { numerator, denominator, decimal };
-}
 
 export default {
   name: 'TasksContainer',

--- a/packages/field-module-tasks/src/components/Tasks.vue
+++ b/packages/field-module-tasks/src/components/Tasks.vue
@@ -97,11 +97,6 @@ export default {
     });
 
     const save = () => commit(current.value);
-    const close = () => {
-      const request = commit(current.value);
-      router.push({ path: '/tasks' });
-      return request;
-    };
     provide('logs', {
       logs,
       current,
@@ -109,7 +104,6 @@ export default {
       openNew,
       update,
       save,
-      close,
     });
   },
 };

--- a/packages/field-module-tasks/src/components/TasksEdit.vue
+++ b/packages/field-module-tasks/src/components/TasksEdit.vue
@@ -305,9 +305,7 @@ export default {
     // ENTITIES
     const { assets, equipment, locations } = inject('assets');
     const { categories, units } = inject('terms');
-    const {
-      current, update, save, close,
-    } = inject('logs');
+    const { current, update, save } = inject('logs');
 
     // QUANTITIES (related to the current log)
     const findUnitName = R.compose(
@@ -343,7 +341,6 @@ export default {
       log: current,
       update,
       save,
-      close,
       units,
       quantities,
       assets: computed(() => partitionOptions(assets.value, current.asset)),

--- a/packages/field-module-tasks/src/components/TasksEdit.vue
+++ b/packages/field-module-tasks/src/components/TasksEdit.vue
@@ -86,14 +86,14 @@
     </farm-card>
 
     <farm-card v-if="log.quantity !== undefined">
-      <h3>{{ $t('Quantities')}} 🚧 UNDER CONSTRUCTION 🚧</h3>
+      <h3>{{ $t('Quantities') }}</h3>
       <label for="quantity" class="control-label ">
         {{ $t('Add new or edit existing quantity')}}
       </label>
       <div v-if="curQuantity" class="form-item form-item-name form-group">
         <select
           :value="curQuantity.measure || $t('Select measure')"
-          @input="updateQuantity('measure', $event.target.value, curQuantID)"
+          @input="updateQuantity('measure', $event.target.value, curQuantity.id)"
           class="custom-select col-sm-3 ">
             <option>{{ $t('Select measure')}}</option>
             <option
@@ -105,13 +105,13 @@
         </select>
         <input
           :value="curQuantity.value"
-          @input="updateQuantity('value', $event.target.value, curQuantID)"
+          @input="updateQuantity('value', $event.target.value, curQuantity.id)"
           :placeholder="$t('Enter value')"
           type="number"
           class="form-control"/>
         <select
           :value="curQuantity.unitId || $t('Select unit')"
-          @input="updateQuantity('units', $event.target.value, curQuantID)"
+          @input="updateQuantity('units', $event.target.value, curQuantity.id)"
           class="custom-select col-sm-3 ">
             <option>{{ $t('Select unit')}}</option>
             <option
@@ -123,7 +123,7 @@
         </select>
         <input
           :value="curQuantity.label || ''"
-          @input="updateQuantity('label', $event.target.value, curQuantID)"
+          @input="updateQuantity('label', $event.target.value, curQuantity.id)"
           :placeholder="$t('Enter label')"
           type="text"
           class="form-control"/>
@@ -133,9 +133,9 @@
           v-if="quantities.length > 0"
           class="list-group">
           <li
-            v-for="quant in quantities"
+            v-for="(quant, i) in quantities"
             v-bind:key="`quantity-${quant.id}`"
-            @click="curQuantID = quant.id"
+            @click="curQuantIndex = i"
             class="list-group-item">
             {{ quant.measure }}&nbsp;
             {{ quant.value }}&nbsp;
@@ -143,7 +143,7 @@
             {{ quant.label }}
             <span
               class="remove-list-item"
-              @click="removeQuantity(quant.id); $event.stopPropagation()">
+              @click="removeQuantity(i); $event.stopPropagation()">
               &#x2715;
             </span>
           </li>
@@ -328,9 +328,8 @@ export default {
       quantities: rawQuantities, addQuantity, updateQuantity, removeQuantity,
     } = inject('quantities');
     const quantities = computed(() => R.map(computeQuantities, rawQuantities.value || []));
-    const curQuantID = ref(null);
-    const curQuantity = computed(() =>
-      quantities?.value?.find(q => q.id === curQuantID.value));
+    const curQuantIndex = ref(-1);
+    const curQuantity = computed(() => quantities.value?.[curQuantIndex.value]);
 
     return {
       parseNotes,
@@ -363,14 +362,17 @@ export default {
       updateNotes(value) {
         update({ notes: { value, format: 'default' } });
       },
-      curQuantID,
+      curQuantIndex,
       curQuantity,
       addQuantity(type) {
-        const id = addQuantity(type);
-        curQuantID.value = id;
+        const i = addQuantity(type);
+        curQuantIndex.value = i;
       },
       updateQuantity,
-      removeQuantity,
+      removeQuantity(i) {
+        if (i >= 0 && i < curQuantIndex) curQuantIndex.value -= 1;
+        removeQuantity(i);
+      },
       toggleRelationship(relationship, { id, type }) {
         const i = current[relationship].findIndex(e => e.id === id);
         if (i < 0) {

--- a/packages/field-module-tasks/src/components/TasksEdit.vue
+++ b/packages/field-module-tasks/src/components/TasksEdit.vue
@@ -87,18 +87,16 @@
 
     <farm-card v-if="log.quantity !== undefined">
       <h3>{{ $t('Quantities')}} 🚧 UNDER CONSTRUCTION 🚧</h3>
-      <!-- <label for="quantity" class="control-label ">
+      <label for="quantity" class="control-label ">
         {{ $t('Add new or edit existing quantity')}}
       </label>
-      <div v-if="currentQuant >= 0" class="form-item form-item-name form-group"> -->
+      <div v-if="currentQuant >= 0" class="form-item form-item-name form-group">
         <!-- To display a placeholder value ONLY when there are no existing
         quantities, we must add the placeholder with an <option> tag and
         select it using the :value option -->
-        <!-- <select
-          :value="(log.quantity
-            && log.quantity.length > 0
-            && log.quantity[currentQuant].measure)
-            ? log.quantity[currentQuant].measure
+        <select
+          :value="(quantities.length > 0 && quantities[currentQuant].measure)
+            ? quantities[currentQuant].measure
             : 'Select measure'"
           @input="updateQuantity('measure', $event.target.value, currentQuant)"
           class="custom-select col-sm-3 ">
@@ -111,19 +109,16 @@
             </option>
         </select>
         <input
-          :value="(log.quantity
-            && log.quantity.length > 0)
-            ? log.quantity[currentQuant].value
+          :value="(quantities.length > 0)
+            ? quantities[currentQuant].value
             : null"
           @input="updateQuantity('value', $event.target.value, currentQuant)"
           :placeholder="$t('Enter value')"
           type="number"
           class="form-control"/>
         <select
-        :value="(log.quantity
-            && log.quantity.length > 0
-            && log.quantity[currentQuant].unit)
-            ? log.quantity[currentQuant].unit.id
+          :value="(quantities.length > 0 && quantities[currentQuant].unit)
+            ? quantities[currentQuant].unit.id
             : 'Select unit'"
           @input="updateQuantity('unit', $event.target.value, currentQuant)"
           class="custom-select col-sm-3 ">
@@ -136,9 +131,8 @@
             </option>
         </select>
         <input
-          :value="(log.quantity
-            && log.quantity.length > 0)
-            ? log.quantity[currentQuant].label
+          :value="(quantities.length > 0)
+            ? quantities[currentQuant].label
             : null"
           @input="updateQuantity('label', $event.target.value, currentQuant)"
           :placeholder="$t('Enter label')"
@@ -147,17 +141,16 @@
       </div>
       <div class="form-item form-group">
         <ul
-          v-if="log.quantity
-            && log.quantity.length > 0"
+          v-if="quantities.length > 0"
           class="list-group">
           <li
-            v-for="(quant, i) in log.quantity"
+            v-for="(quant, i) in quantities"
             v-bind:key="`quantity-${i}`"
             @click="currentQuant = i"
             class="list-group-item">
             {{ quant.measure }}&nbsp;
             {{ quant.value }}&nbsp;
-            {{ (quantUnitNames.length > 0) ? quantUnitNames[i] : '' }}&nbsp;
+            {{ quant.units }}&nbsp;
             {{ quant.label }}
             <span class="remove-list-item" @click="removeQuant(i); $event.stopPropagation()">
               &#x2715;
@@ -173,7 +166,7 @@
           name="addNewQuantity">
           {{$t('Add another quantity')}}
         </button>
-      </div> -->
+      </div>
     </farm-card>
 
     <farm-card>
@@ -319,6 +312,11 @@ export default {
     const {
       current, update, save, close,
     } = inject('logs');
+    const { quantities } = inject('quantities');
+    const computeQuantities = R.map(R.evolve({
+      units: u => R.find(R.propEq('id', u.id), units.value)?.name || '',
+      value: v => v.decimal || v.numerator / v.denominator,
+    }));
 
     return {
       parseNotes,
@@ -335,6 +333,7 @@ export default {
       save,
       close,
       units,
+      quantities: computed(() => computeQuantities(quantities.value)),
       assets: computed(() => partitionOptions(assets.value, current.asset)),
       equipment: computed(() => partitionOptions(equipment.value, current.equipment)),
       locations: computed(() => partitionOptions(locations.value, current.location)),
@@ -416,27 +415,6 @@ export default {
   //       ...this.log.quantity.slice(index + 1),
   //     ];
   //     this.update({ quantity: newQuant });
-  //   },
-  // },
-
-  // computed: {
-  //   quantUnitNames() {
-  //     if (this.units.length > 0 && this.log?.quantity.length > 0) {
-  //       const unitNames = [];
-  //       this.log.quantity.forEach((quant) => {
-  //         if (quant.unit) {
-  //           this.units.forEach((unit) => {
-  //             if (parseInt(unit.id, 10) === parseInt(quant.unit.id, 10)) {
-  //               unitNames.push(unit.name);
-  //             }
-  //           });
-  //         } else {
-  //           unitNames.push(null);
-  //         }
-  //       });
-  //       return unitNames;
-  //     }
-  //     return [];
   //   },
   // },
 };

--- a/packages/field-module-tasks/src/components/TasksEdit.vue
+++ b/packages/field-module-tasks/src/components/TasksEdit.vue
@@ -253,8 +253,9 @@ const {
   computed, inject, reactive, ref,
 } = window.Vue;
 const {
-  R,
   parseNotes,
+  R,
+  toDecimal,
 } = window.lib;
 
 // Used to separate assets, areas, etc into those that have already been added
@@ -282,12 +283,6 @@ const quantMeasures = [
   'ratio',
   'probability',
 ];
-
-function toDecimal(value) {
-  if (!value || typeof value !== 'object') return 0;
-  const { decimal, numerator, denominator } = value;
-  return decimal || numerator / denominator;
-}
 
 export default {
   name: 'TasksEdit',


### PR DESCRIPTION
This will entail most of the remaining work for the [alpha.8 release](https://github.com/farmOS/field-kit/milestone/8), which brings the Tasks module into near full parity with the "General" tab of v1 "Edit Log" screen. It restores the "Quantities" section and adds new `add()`, `drop()` and `link()` methods to the Entities API, thereby resolving #462 and #505.

See https://github.com/farmOS/field-kit/issues/505#issuecomment-1367588943 for more details on the implementation of the `link()` method, and how it's used to link quantities to a log.