### PR TITLE
Add .github/ISSUE_TEMPLATE config to encourage forum discussions as a first step

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,36 @@
+---
+name: Bug report
+about: Create a report to help us improve.
+labels: bug
+
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Screenshots**
+If applicable, add screenshots to help explain your problem.
+
+**Desktop (please complete the following information):**
+ - OS: [e.g. iOS]
+ - Browser [e.g. chrome, safari]
+ - Version [e.g. 22]
+
+**Smartphone (please complete the following information):**
+ - Device: [e.g. iPhone6]
+ - OS: [e.g. iOS8.1]
+ - Browser [e.g. stock browser, safari]
+ - Version [e.g. 22]
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: true
+contact_links:
+  - name: farmOS Community Forum
+    url: https://farmOS.discourse.group/
+    about: Questions, support requests, and feature discussions take place in the forum.
+  - name: farmOS Chat Room
+    url: https://app.element.io/#/room/#farmOS:matrix.org
+    about: Join us in the farmOS chat room on IRC and Matrix.org.


### PR DESCRIPTION
This is copied from the farmOS/farmOS repo. The goal is to direct people to the forum and chat for more general discussions, feature requests, etc, and reserve the GitHub repo for bug reports and internal task management.